### PR TITLE
Add wrappers for the standard input, output, and error streams

### DIFF
--- a/code/logic/fossil/io/stream.h
+++ b/code/logic/fossil/io/stream.h
@@ -17,10 +17,6 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#define FOSSIL_STDIN  stdin
-#define FOSSIL_STDOUT stdout
-#define FOSSIL_STDERR stderr
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,6 +28,14 @@ typedef struct {
     FILE *file;                                       // Pointer to the FILE structure for the stream
     char filename[500]; // Array to store the filename
 } fossil_fstream_t;
+
+extern fossil_fstream_t *FOSSIL_STDIN;
+extern fossil_fstream_t *FOSSIL_STDOUT;
+extern fossil_fstream_t *FOSSIL_STDERR;
+
+#define FOSSIL_STDIN  (FOSSIL_STDIN)
+#define FOSSIL_STDOUT (FOSSIL_STDOUT)
+#define FOSSIL_STDERR (FOSSIL_STDERR)
 
 /**
  * Reopen a stream with a new file.


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description

This change introduces `fossil_fstream_t` wrappers for the standard input, output, and error streams, defined as `FOSSIL_STDIN`, `FOSSIL_STDOUT`, and `FOSSIL_STDERR`. These are now declared as external `fossil_fstream_t*` pointers, replacing the previous direct mappings to `stdin`, `stdout`, and `stderr`. This provides a consistent and extensible abstraction over standard streams, aligning them with the rest of the `fossil_fstream_` API for improved portability and stream management across platforms.

## Testing
Same test to ensure everything works

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
