### PR TITLE
Create new NStream API

### DIFF
--- a/code/logic/error.c
+++ b/code/logic/error.c
@@ -40,7 +40,7 @@ const char *fossil_io_what(fossil_status_t error_code) {
     switch (error_code) {
         // Success and General Errors
         case FOSSIL_ERROR_OK: return "No error, operation successful.";
-        case FOSSIL_ERROR_NULL_POINTER: return "Null pointer encountered.";
+        case FOSSIL_ERROR_CNULL_POINTER: return "Null pointer encountered.";
         case FOSSIL_ERROR_INVALID_ARGUMENT: return "Invalid argument provided.";
         case FOSSIL_ERROR_TYPE_MISMATCH: return "Type mismatch encountered.";
         case FOSSIL_ERROR_INVALID_OPERATION: return "Invalid operation.";

--- a/code/logic/fossil/io/error.h
+++ b/code/logic/fossil/io/error.h
@@ -21,7 +21,7 @@ extern "C" {
 typedef enum {
     // Success and General Errors
     FOSSIL_ERROR_OK = 0,
-    FOSSIL_ERROR_NULL_POINTER,
+    FOSSIL_ERROR_CNULL_POINTER,
     FOSSIL_ERROR_INVALID_ARGUMENT,
     FOSSIL_ERROR_TYPE_MISMATCH,
     FOSSIL_ERROR_INVALID_OPERATION,
@@ -200,7 +200,7 @@ namespace fossil {
         enum class ErrorCode {
             // Success and General Errors
             OK = FOSSIL_ERROR_OK,
-            NULL_POINTER = FOSSIL_ERROR_NULL_POINTER,
+            NULL_POINTER = FOSSIL_ERROR_CNULL_POINTER,
             INVALID_ARGUMENT = FOSSIL_ERROR_INVALID_ARGUMENT,
             TYPE_MISMATCH = FOSSIL_ERROR_TYPE_MISMATCH,
             INVALID_OPERATION = FOSSIL_ERROR_INVALID_OPERATION,

--- a/code/logic/fossil/io/network.h
+++ b/code/logic/fossil/io/network.h
@@ -21,6 +21,89 @@
 extern "C" {
 #endif
 
+/**
+ * @file network.c
+ * @brief Network logic implementation for handling communication protocols and client types.
+ *
+ * This file contains the core logic for managing network communication in the application.
+ * It is responsible for implementing various protocols and handling different types of clients
+ * that interact with the system. The following details outline the key aspects of the network
+ * logic:
+ *
+ * ## Supported Protocols:
+ * 1. **TCP (Transmission Control Protocol):**
+ *    - Provides reliable, ordered, and error-checked delivery of data.
+ *    - Used for persistent connections and critical data exchange.
+ *    - Ensures data integrity and retransmission in case of packet loss.
+ *
+ * 2. **UDP (User Datagram Protocol):**
+ *    - Provides connectionless communication with minimal overhead.
+ *    - Suitable for real-time applications where speed is prioritized over reliability.
+ *    - Commonly used for streaming, gaming, and other low-latency scenarios.
+ *
+ * 3. **HTTP/HTTPS:**
+ *    - Supports web-based communication using the Hypertext Transfer Protocol.
+ *    - HTTPS ensures secure communication via SSL/TLS encryption.
+ *    - Used for RESTful APIs and web client interactions.
+ *
+ * 4. **WebSocket:**
+ *    - Enables full-duplex communication channels over a single TCP connection.
+ *    - Ideal for real-time applications such as chat systems and live updates.
+ *
+ * ## Client Types:
+ * 1. **Standard Clients:**
+ *    - General-purpose clients that use standard protocols like HTTP or WebSocket.
+ *    - Typically include web browsers, mobile apps, and desktop applications.
+ *
+ * 2. **Embedded Clients:**
+ *    - Lightweight clients running on embedded systems or IoT devices.
+ *    - Often use UDP or custom lightweight protocols for communication.
+ *
+ * 3. **Service Clients:**
+ *    - Backend services or microservices that interact with the system.
+ *    - May use HTTP APIs, gRPC, or other service-to-service communication protocols.
+ *
+ * 4. **Real-Time Clients:**
+ *    - Clients requiring low-latency communication, such as gaming or streaming applications.
+ *    - Often rely on WebSocket or UDP for real-time data exchange.
+ *
+ * ## Supported Flags:
+ * - **Protocol Flags:**
+ *   - `tcp`: Specifies the use of the TCP protocol.
+ *   - `udp`: Specifies the use of the UDP protocol.
+ *   - `http`: Specifies the use of the HTTP protocol.
+ *   - `https`: Specifies the use of the HTTPS protocol.
+ *   - `raw`: Specifies the use of raw sockets.
+ *   - `icmp`: Specifies the use of ICMP protocol.
+ *   - `sctp`: Specifies the use of SCTP protocol.
+ *   - `ftp`: Specifies the use of the FTP protocol.
+ *   - `ssh`: Specifies the use of the SSH protocol.
+ *   - `dns`: Specifies the use of the DNS protocol.
+ *   - `ntp`: Specifies the use of the NTP protocol.
+ *   - `smtp`: Specifies the use of the SMTP protocol.
+ *   - `pop3`: Specifies the use of the POP3 protocol.
+ *   - `imap`: Specifies the use of the IMAP protocol.
+ *   - `ldap`: Specifies the use of the LDAP protocol.
+ *   - `mqtt`: Specifies the use of the MQTT protocol.
+ *
+ * - **Client Type Flags:**
+ *   - `mail-server`: Represents a mail server client.
+ *   - `server`: Represents a general server client.
+ *   - `mail-client`: Represents a mail client.
+ *   - `client`: Represents a general client.
+ *   - `mail-bot`: Represents an automated mail bot client.
+ *   - `bot`: Represents a general bot client.
+ *   - `multicast`: Represents a multicast client.
+ *   - `broadcast`: Represents a broadcast client.
+ *
+ * ## Additional Notes:
+ * - The implementation ensures scalability and fault tolerance for handling multiple clients
+ *   simultaneously.
+ * - Security measures, such as encryption and authentication, are integrated to protect
+ *   communication channels.
+ * - The file is designed to be modular, allowing easy extension for new protocols or client types.
+ */
+
 typedef struct fossil_nstream_t fossil_nstream_t;
 
 typedef enum {

--- a/code/logic/fossil/io/network.h
+++ b/code/logic/fossil/io/network.h
@@ -14,31 +14,31 @@
 #ifndef FOSSIL_IO_NETWORK_H
 #define FOSSIL_IO_NETWORK_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef _WIN32
-    #include <winsock2.h>
-    #include <ws2tcpip.h>
-    typedef SOCKET fossil_io_socket_t;
-    #define FOSSIL_IO_INVALID_SOCKET INVALID_SOCKET
+#include <winsock2.h>
 #else
-    #include <sys/types.h>
-    #include <sys/socket.h>
-    #include <netinet/in.h>
-    #include <arpa/inet.h>
-    #include <netdb.h>
-    #include <unistd.h>
-    #define closesocket close
-    typedef int fossil_io_socket_t;
-    #define FOSSIL_IO_INVALID_SOCKET (-1)
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
 #endif
-
-#define FOSSIL_IO_SOCKET_TYPE_TCP SOCK_STREAM
-#define FOSSIL_IO_SOCKET_TYPE_UDP SOCK_DGRAM
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Network stream structure
+typedef struct fossil_nstream_t {
+    int socket;            // Socket file descriptor
+    int is_tls;            // Whether the stream uses TLS
+    struct sockaddr_in addr;  // Address for connections
+    char protocol[16];         // Protocol type (TCP, UDP, etc.)
+} fossil_nstream_t;
 
 /**
  * Initialize the network stack. This function is necessary for Windows
@@ -47,133 +47,158 @@ extern "C" {
  * 
  * @return 0 on success, non-zero on failure.
  */
-int fossil_io_network_create(void);
+fossil_nstream_t *fossil_nstream_open(const char *protocol, const char *host, const char *port, const char *flags);
 
 /**
- * Clean up the network stack. This function is necessary for Windows
- * platforms to clean up the Winsock library. On other platforms, it may
- * perform other necessary clean-up operations.
+ * Send data through the network stream.
+ *
+ * @param ns The network stream to send data through.
+ * @param buf The buffer containing the data to send.
+ * @param len The length of the data to send.
+ * @return The number of bytes sent, or -1 on failure.
  */
-void fossil_io_network_destroy(void);
+ssize_t fossil_nstream_send(fossil_nstream_t *ns, const void *buf, size_t len);
 
 /**
- * Create a new socket of the specified type (TCP or UDP).
+ * Receive data through the network stream.
  * 
- * @param type The type of socket to create (e.g., SOCK_STREAM for TCP, SOCK_DGRAM for UDP).
- * @return A valid socket on success, or FOSSIL_IO_INVALID_SOCKET on failure.
+ * @param ns The network stream to receive data from.
+ * @param buf The buffer to store the received data.
+ * @param len The maximum length of data to receive.
+ * @return The number of bytes received, or -1 on failure.
  */
-fossil_io_socket_t fossil_io_network_create_socket(int type);
+ssize_t fossil_nstream_recv(fossil_nstream_t *ns, void *buf, size_t len);
 
 /**
- * Bind a socket to a specific IP address and port. This function associates
- * the socket with a local address so that it can listen for incoming connections
- * or send data.
- * 
- * @param sock The socket to bind.
- * @param ip The IP address to bind to (e.g., "127.0.0.1" for localhost).
- * @param port The port number to bind to.
- * @return 0 on success, -1 on failure.
- */
-int fossil_io_network_bind(fossil_io_socket_t sock, const char *ip, uint16_t port);
-
-/**
- * Listen for incoming connections on a bound socket. This function puts the
- * socket into a state where it can accept incoming connection requests.
- * 
- * @param sock The socket to listen on.
+ * Listen on a network stream (for servers).
+ *
+ * @param ns The network stream to listen on.
  * @param backlog The maximum length of the queue of pending connections.
  * @return 0 on success, -1 on failure.
  */
-int fossil_io_network_listen(fossil_io_socket_t sock, int backlog);
+int fossil_nstream_listen(fossil_nstream_t *ns, int backlog);
 
 /**
  * Accept a new incoming connection on a listening socket. This function
  * extracts the first connection request on the queue of pending connections
  * and creates a new socket for the connection.
  * 
- * @param sock The listening socket.
- * @param client_ip A buffer to store the IP address of the connecting client.
- * @param client_port A pointer to store the port number of the connecting client.
- * @return A valid socket for the new connection on success, or FOSSIL_IO_INVALID_SOCKET on failure.
+ * @param ns The listening network stream.
+ * @return A valid network stream for the new connection on success, or NULL on failure.
  */
-fossil_io_socket_t fossil_io_network_accept(fossil_io_socket_t sock, char *client_ip, uint16_t *client_port);
+fossil_nstream_t *fossil_nstream_accept(fossil_nstream_t *ns);
+
+/**
+ * Close the network stream. This function releases the resources associated with the
+ * network stream and closes the connection.
+ * 
+ * @param ns The network stream to close.
+ */
+void fossil_nstream_close(fossil_nstream_t *ns);
+
+/**
+ * Set the socket to non-blocking mode.
+ * 
+ * @param ns The network stream to modify.
+ * @param enable 1 to enable non-blocking mode, 0 to disable it.
+ * @return 0 on success, -1 on failure.
+ */
+int fossil_nstream_set_nonblocking(fossil_nstream_t *ns, int enable);
+
+/**
+ * Wait for the socket to become readable.
+ * 
+ * @param ns The network stream to wait on.
+ * @param timeout_ms The timeout in milliseconds.
+ * @return 0 on success, -1 on failure, or 1 if the timeout occurred.
+ */
+int fossil_nstream_wait_readable(fossil_nstream_t *ns, int timeout_ms);
+
+/**
+ * Wait for the socket to become writable.
+ * 
+ * @param ns The network stream to wait on.
+ * @param timeout_ms The timeout in milliseconds.
+ * @return 0 on success, -1 on failure, or 1 if the timeout occurred.
+ */
+int fossil_nstream_wait_writable(fossil_nstream_t *ns, int timeout_ms);
 
 /**
  * Connect to a remote server. This function establishes a connection to a
  * specified IP address and port.
  * 
- * @param sock The socket to use for the connection.
- * @param ip The IP address of the remote server.
+ * @param ns The network stream to use for the connection.
+ * @param host The hostname or IP address of the remote server.
  * @param port The port number of the remote server.
+ * @param timeout_ms The timeout in milliseconds.
  * @return 0 on success, -1 on failure.
  */
-int fossil_io_network_connect(fossil_io_socket_t sock, const char *ip, uint16_t port);
+int fossil_nstream_connect_timeout(fossil_nstream_t *ns, const char *host, const char *port, int timeout_ms);
 
 /**
- * Send data over a connected socket. This function transmits data to the
- * remote peer connected to the socket.
+ * Get the IP address and port of the connected peer.
  * 
- * @param sock The socket to use for sending data.
- * @param data A pointer to the data to be sent.
- * @param len The length of the data to be sent.
- * @return The number of bytes sent, or -1 on failure.
+ * @param ns The network stream to query.
+ * @param ip_str A buffer to store the IP address as a string.
+ * @param ip_len The length of the IP address buffer.
+ * @param port A pointer to store the port number.
+ * @return 0 on success, -1 on failure.
  */
-int fossil_io_network_send(fossil_io_socket_t sock, const void *data, size_t len);
+int fossil_nstream_get_peer_info(fossil_nstream_t *ns, char *ip_str, size_t ip_len, uint16_t *port);
 
 /**
- * Receive data from a connected socket. This function reads data from the
- * remote peer connected to the socket.
+ * Get the local IP address and port of the socket.
  * 
- * @param sock The socket to use for receiving data.
- * @param buffer A buffer to store the received data.
- * @param len The maximum length of data to be received.
+ * @param ns The network stream to query.
+ * @param ip_str A buffer to store the local IP address as a string.
+ * @param ip_len The length of the IP address buffer.
+ * @param port A pointer to store the local port number.
+ * @return 0 on success, -1 on failure.
+ */
+ssize_t fossil_nstream_send_line(fossil_nstream_t *ns, const char *line);
+
+/**
+ * Receive a line of text from the network stream. This function reads data
+ * until a newline character is encountered.
+ * 
+ * @param ns The network stream to receive data from.
+ * @param buf The buffer to store the received line.
+ * @param max_len The maximum length of the buffer.
  * @return The number of bytes received, or -1 on failure.
  */
-int fossil_io_network_receive(fossil_io_socket_t sock, void *buffer, size_t len);
+ssize_t fossil_nstream_recv_line(fossil_nstream_t *ns, char *buf, size_t max_len);
 
 /**
- * Close a socket. This function releases the resources associated with the
- * socket and closes the connection.
+ * Send data over a TLS connection.
  * 
- * @param sock The socket to be closed.
+ * @param ns The network stream to send data through.
+ * @param buf The buffer containing the data to send.
+ * @param len The length of the data to send.
+ * @return The number of bytes sent, or -1 on failure.
  */
-void fossil_io_network_close(fossil_io_socket_t sock);
+ssize_t fossil_nstream_ssl_send(fossil_nstream_t *ns, const void *buf, size_t len);
 
 /**
- * Send data to a specific IP address and port using a UDP socket. This function
- * transmits data to the specified address and port without establishing a connection.
+ * Receive data over a TLS connection.
  * 
- * @param sock The socket to use for sending data.
- * @param data A pointer to the data to be sent.
- * @param len The length of the data to be sent.
+ * @param ns The network stream to receive data from.
+ * @param buf The buffer to store the received data.
+ * @param len The maximum length of data to receive.
+ * @return The number of bytes received, or -1 on failure.
+ */
+ssize_t fossil_nstream_ssl_recv(fossil_nstream_t *ns, void *buf, size_t len);
+
+/**
+ * Send data over a UDP socket.
+ * 
+ * @param ns The network stream to send data through.
+ * @param buf The buffer containing the data to send.
+ * @param len The length of the data to send.
  * @param ip The IP address of the destination.
  * @param port The port number of the destination.
  * @return The number of bytes sent, or -1 on failure.
  */
-int fossil_io_network_sendto(fossil_io_socket_t sock, const void *data, size_t len, const char *ip, uint16_t port);
-
-/**
- * Receive data from a specific IP address and port using a UDP socket. This function
- * reads data from the specified address and port without establishing a connection.
- * 
- * @param sock The socket to use for receiving data.
- * @param buffer A buffer to store the received data.
- * @param len The maximum length of data to be received.
- * @param ip A buffer to store the IP address of the sender.
- * @param port A pointer to store the port number of the sender.
- * @return The number of bytes received, or -1 on failure.
- */
-int fossil_io_network_recvfrom(fossil_io_socket_t sock, void *buffer, size_t len, char *ip, uint16_t *port);
-
-/**
- * Bridge function for network operations. This function can be used to
- * transfer data between two sockets, effectively bridging them.
- * 
- * @param sock1 The first socket.
- * @param sock2 The second socket.
- * @return 0 on success, -1 on failure.
- */
-int fossil_io_network_bridge(fossil_io_socket_t sock1, fossil_io_socket_t sock2);
+const char *fossil_nstream_strerror(void);
 
 #ifdef __cplusplus
 }
@@ -189,168 +214,173 @@ namespace fossil {
         /**
          * Class for network operations.
          */
-        class Network {
+        class NStream {
         public:
+
             /**
-             * Initialize the network stack. This function is necessary for Windows
-             * platforms to set up the Winsock library. On other platforms, it may
-             * perform other necessary initializations.
+             * Constructor for NStream.
              * 
-             * @return 0 on success, non-zero on failure.
+             * @param protocol The protocol to use (e.g., "tcp", "udp").
+             * @param host The hostname or IP address.
+             * @param port The port number.
+             * @param flags Additional flags (e.g., "server").
              */
-            static int init(void) {
-                return fossil_io_network_create();
+            NStream(const std::string &protocol, const std::string &host, const std::string &port, const std::string &flags) {
+                ns = fossil_nstream_open(protocol.c_str(), host.c_str(), port.c_str(), flags.c_str());
             }
 
             /**
-             * Clean up the network stack. This function is necessary for Windows
-             * platforms to clean up the Winsock library. On other platforms, it may
-             * perform other necessary clean-up operations.
+             * Constructor for NStream with an existing socket.
+             * 
+             * @param socket The existing socket file descriptor.
              */
-            static void cleanup(void) {
-                fossil_io_network_destroy();
+            ~NStream() {
+                if (ns) {
+                    fossil_nstream_close(ns);
+                }
             }
 
             /**
-             * Create a new socket of the specified type (TCP or UDP).
-             * 
-             * @param type The type of socket to create (e.g., SOCK_STREAM for TCP, SOCK_DGRAM for UDP).
-             * @return A valid socket on success, or FOSSIL_IO_INVALID_SOCKET on failure.
+             * Send data through the network stream.
+             *
+             * @param buf The buffer containing the data to send.
+             * @param len The length of the data to send.
+             * @return The number of bytes sent, or -1 on failure.
              */
-            static fossil_io_socket_t create_socket(int type) {
-                return fossil_io_network_create_socket(type);
+            ssize_t send(const void *buf, size_t len) {
+                return fossil_nstream_send(ns, buf, len);
             }
 
             /**
-             * Bind a socket to a specific IP address and port. This function associates
-             * the socket with a local address so that it can listen for incoming connections
-             * or send data.
+             * Receive data through the network stream.
              * 
-             * @param sock The socket to bind.
-             * @param ip The IP address to bind to (e.g., "127.0.0.1" for localhost).
-             * @param port The port number to bind to.
-             * @return 0 on success, -1 on failure.
+             * @param buf The buffer to store the received data.
+             * @param len The maximum length of data to receive.
+             * @return The number of bytes received, or -1 on failure.
              */
-            static int bind(fossil_io_socket_t sock, const char *ip, uint16_t port) {
-                return fossil_io_network_bind(sock, ip, port);
+            ssize_t recv(void *buf, size_t len) {
+                return fossil_nstream_recv(ns, buf, len);
             }
 
             /**
-             * Listen for incoming connections on a bound socket. This function puts the
-             * socket into a state where it can accept incoming connection requests.
-             * 
-             * @param sock The socket to listen on.
+             * Listen on a network stream (for servers).
+             *
              * @param backlog The maximum length of the queue of pending connections.
              * @return 0 on success, -1 on failure.
              */
-            static int listen(fossil_io_socket_t sock, int backlog) {
-                return fossil_io_network_listen(sock, backlog);
+            int listen(int backlog) {
+                return fossil_nstream_listen(ns, backlog);
             }
 
             /**
-             * Accept a new incoming connection on a listening socket. This function
-             * extracts the first connection request on the queue of pending connections
-             * and creates a new socket for the connection.
+             * Accept a new incoming connection on a listening socket.
              * 
-             * @param sock The listening socket.
-             * @param client_ip A buffer to store the IP address of the connecting client.
-             * @param client_port A pointer to store the port number of the connecting client.
-             * @return A valid socket for the new connection on success, or FOSSIL_IO_INVALID_SOCKET on failure.
+             * @return A valid network stream for the new connection on success, or nullptr on failure.
              */
-            static fossil_io_socket_t accept(fossil_io_socket_t sock, char *client_ip, uint16_t *client_port) {
-                return fossil_io_network_accept(sock, client_ip, client_port);
+            NStream *accept() {
+                fossil_nstream_t *new_ns = fossil_nstream_accept(ns);
+                return new_ns ? new NStream(new_ns) : nullptr;
             }
 
             /**
-             * Connect to a remote server. This function establishes a connection to a
-             * specified IP address and port.
+             * Set the socket to non-blocking mode.
              * 
-             * @param sock The socket to use for the connection.
-             * @param ip The IP address of the remote server.
+             * @param enable 1 to enable non-blocking mode, 0 to disable it.
+             * @return 0 on success, -1 on failure.
+             */
+            int set_non_blocking(int enable) {
+                return fossil_nstream_set_nonblocking(ns, enable);
+            }
+
+            /**
+             * Wait for the socket to become readable.
+             * 
+             * @param timeout_ms The timeout in milliseconds.
+             * @return 0 on success, -1 on failure, or 1 if the timeout occurred.
+             */
+            int wait_readable(int timeout_ms) {
+                return fossil_nstream_wait_readable(ns, timeout_ms);
+            }
+
+            /**
+             * Wait for the socket to become writable.
+             * 
+             * @param timeout_ms The timeout in milliseconds.
+             * @return 0 on success, -1 on failure, or 1 if the timeout occurred.
+             */
+            int wait_writable(int timeout_ms) {
+                return fossil_nstream_wait_writable(ns, timeout_ms);
+            }
+
+            /**
+             * Connect to a remote server with a timeout.
+             * 
+             * @param host The hostname or IP address of the remote server.
              * @param port The port number of the remote server.
+             * @param timeout_ms The timeout in milliseconds.
              * @return 0 on success, -1 on failure.
              */
-            static int connect(fossil_io_socket_t sock, const char *ip, uint16_t port) {
-                return fossil_io_network_connect(sock, ip, port);
+            int connect_timeout(const std::string &host, const std::string &port, int timeout_ms) {
+                return fossil_nstream_connect_timeout(ns, host.c_str(), port.c_str(), timeout_ms);
             }
 
             /**
-             * Send data over a connected socket. This function transmits data to the
-             * remote peer connected to the socket.
+             * Get the IP address and port of the connected peer.
              * 
-             * @param sock The socket to use for sending data.
-             * @param data A pointer to the data to be sent.
-             * @param len The length of the data to be sent.
-             * @return The number of bytes sent, or -1 on failure.
-             */
-            static int send(fossil_io_socket_t sock, const void *data, size_t len) {
-                return fossil_io_network_send(sock, data, len);
-            }
-
-            /**
-             * Receive data from a connected socket. This function reads data from the
-             * remote peer connected to the socket.
-             * 
-             * @param sock The socket to use for receiving data.
-             * @param buffer A buffer to store the received data.
-             * @param len The maximum length of data to be received.
-             * @return The number of bytes received, or -1 on failure.
-             */
-            static int receive(fossil_io_socket_t sock, void *buffer, size_t len) {
-                return fossil_io_network_receive(sock, buffer, len);
-            }
-
-            /**
-             * Close a socket. This function releases the resources associated with the
-             * socket and closes the connection.
-             * 
-             * @param sock The socket to be closed.
-             */
-            static void close(fossil_io_socket_t sock) {
-                fossil_io_network_close(sock);
-            }
-
-            /**
-             * Send data to a specific IP address and port using a UDP socket. This function
-             * transmits data to the specified address and port without establishing a connection.
-             * 
-             * @param sock The socket to use for sending data.
-             * @param data A pointer to the data to be sent.
-             * @param len The length of the data to be sent.
-             * @param ip The IP address of the destination.
-             * @param port The port number of the destination.
-             * @return The number of bytes sent, or -1 on failure.
-             */
-            static int sendto(fossil_io_socket_t sock, const void *data, size_t len, const char *ip, uint16_t port) {
-                return fossil_io_network_sendto(sock, data, len, ip, port);
-            }
-
-            /**
-             * Receive data from a specific IP address and port using a UDP socket. This function
-             * reads data from the specified address and port without establishing a connection.
-             * 
-             * @param sock The socket to use for receiving data.
-             * @param buffer A buffer to store the received data.
-             * @param len The maximum length of data to be received.
-             * @param ip A buffer to store the IP address of the sender.
-             * @param port A pointer to store the port number of the sender.
-             * @return The number of bytes received, or -1 on failure.
-             */
-            static int recvfrom(fossil_io_socket_t sock, void *buffer, size_t len, char *ip, uint16_t *port) {
-                return fossil_io_network_recvfrom(sock, buffer, len, ip, port);
-            }
-
-            /**
-             * Bridge function for network operations. This function can be used to
-             * transfer data between two sockets, effectively bridging them.
-             * 
-             * @param sock1 The first socket.
-             * @param sock2 The second socket.
+             * @param ip_str A string to store the IP address.
+             * @param port A reference to store the port number.
              * @return 0 on success, -1 on failure.
              */
-            static int bridge(fossil_io_socket_t sock1, fossil_io_socket_t sock2) {
-                return fossil_io_network_bridge(sock1, sock2);
+            int get_peer_info(std::string &ip_str, uint16_t &port) {
+                char ip_buf[INET_ADDRSTRLEN];
+                int result = fossil_nstream_get_peer_info(ns, ip_buf, sizeof(ip_buf), &port);
+                if (result == 0) {
+                    ip_str = ip_buf;
+                }
+                return result;
             }
+
+            /**
+             * Send a line of text through the network stream.
+             * 
+             * @param line The line of text to send.
+             * @return The number of bytes sent, or -1 on failure.
+             */
+            ssize_t send_line(const std::string &line) {
+                return fossil_nstream_send_line(ns, line.c_str());
+            }
+
+            /**
+             * Receive a line of text from the network stream.
+             * 
+             * @param buf A string to store the received line.
+             * @param max_len The maximum length of the buffer.
+             * @return The number of bytes received, or -1 on failure.
+             */
+            ssize_t recv_line(std::string &buf, size_t max_len) {
+                char *temp_buf = new char[max_len];
+                ssize_t result = fossil_nstream_recv_line(ns, temp_buf, max_len);
+                if (result >= 0) {
+                    buf.assign(temp_buf, result);
+                }
+                delete[] temp_buf;
+                return result;
+            }
+
+            /**
+             * Get a string describing the last error.
+             * 
+             * @return A string describing the last error.
+             */
+            const char *str_error() {
+                return fossil_nstream_strerror();
+            }
+
+        private:
+            fossil_nstream_t *ns;
+
+            // Private constructor for internal use
+            NStream(fossil_nstream_t *existing_ns) : ns(existing_ns) {}
 
         };
     }
@@ -358,4 +388,4 @@ namespace fossil {
 
 #endif
 
-#endif /* FOSSIL_IO_FRAMEWORK_H */
+#endif /* FOSSIL_IO_NETWORK_H */

--- a/code/logic/fossil/io/network.h
+++ b/code/logic/fossil/io/network.h
@@ -202,6 +202,7 @@ const char *fossil_nstream_strerror(void);
 
 #ifdef __cplusplus
 }
+#include <string>
 
 /**
  * C++ wrapper for the output functions.

--- a/code/logic/fossil/io/network.h
+++ b/code/logic/fossil/io/network.h
@@ -15,194 +15,127 @@
 #define FOSSIL_IO_NETWORK_H
 
 #include <stddef.h>
-#include <stdint.h>
-
-#ifdef _WIN32
-#include <winsock2.h>
-#else
-#include <sys/select.h>  // For fd_set and select
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <errno.h>
-#endif
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// Network stream structure
-typedef struct fossil_nstream_t {
-    int socket;            // Socket file descriptor
-    int is_tls;            // Whether the stream uses TLS
-    struct sockaddr_in addr;  // Address for connections
-    char protocol[16];         // Protocol type (TCP, UDP, etc.)
-} fossil_nstream_t;
+typedef struct fossil_nstream_t fossil_nstream_t;
+
+typedef enum {
+    FOSSIL_PROTO_TCP,
+    FOSSIL_PROTO_UDP,
+    FOSSIL_PROTO_RAW,
+    FOSSIL_PROTO_ICMP,
+    FOSSIL_PROTO_SCTP,
+    FOSSIL_PROTO_HTTP,
+    FOSSIL_PROTO_HTTPS,
+    FOSSIL_PROTO_FTP,
+    FOSSIL_PROTO_SSH,
+    FOSSIL_PROTO_DNS,
+    FOSSIL_PROTO_NTP,
+    FOSSIL_PROTO_SMTP,
+    FOSSIL_PROTO_POP3,
+    FOSSIL_PROTO_IMAP,
+    FOSSIL_PROTO_LDAP,
+    FOSSIL_PROTO_MQTT,
+    FOSSIL_PROTO_UNKNOWN
+} fossil_protocol_t;
+
+typedef enum {
+    FOSSIL_CLIENT_MAIL_SERVER,
+    FOSSIL_CLIENT_SERVER,
+    FOSSIL_CLIENT_MAIL_CLIENT,
+    FOSSIL_CLIENT_CLIENT,
+    FOSSIL_CLIENT_MAIL_BOT,
+    FOSSIL_CLIENT_BOT,
+    FOSSIL_CLIENT_MULTICAST,
+    FOSSIL_CLIENT_BROADCAST,
+    FOSSIL_CLIENT_UNKNOWN
+} fossil_client_type_t;
 
 /**
- * Initialize the network stack. This function is necessary for Windows
- * platforms to set up the Winsock library. On other platforms, it may
- * perform other necessary initializations.
- * 
- * @return 0 on success, non-zero on failure.
- */
-fossil_nstream_t *fossil_nstream_open(const char *protocol, const char *host, const char *port, const char *flags);
-
-/**
- * Send data through the network stream.
+ * Create a new network stream.
  *
- * @param ns The network stream to send data through.
- * @param buf The buffer containing the data to send.
- * @param len The length of the data to send.
- * @return The number of bytes sent, or -1 on failure.
+ * @param protocol_flag The protocol to use (e.g., "tcp", "udp").
+ * @param client_type_flag The type of client (e.g., "server", "client").
+ * @return A pointer to the newly created network stream, or NULL on failure.
  */
-ssize_t fossil_nstream_send(fossil_nstream_t *ns, const void *buf, size_t len);
+fossil_nstream_t *fossil_nstream_create(const char *protocol_flag, const char *client_type_flag);
 
 /**
- * Receive data through the network stream.
- * 
- * @param ns The network stream to receive data from.
- * @param buf The buffer to store the received data.
- * @param len The maximum length of data to receive.
- * @return The number of bytes received, or -1 on failure.
- */
-ssize_t fossil_nstream_recv(fossil_nstream_t *ns, void *buf, size_t len);
-
-/**
- * Listen on a network stream (for servers).
+ * Connect a network stream to a remote host.
  *
- * @param ns The network stream to listen on.
- * @param backlog The maximum length of the queue of pending connections.
- * @return 0 on success, -1 on failure.
+ * @param stream The network stream to connect.
+ * @param host The hostname or IP address of the remote host.
+ * @param port The port number to connect to.
+ * @return 0 on success, or -1 on failure.
  */
-int fossil_nstream_listen(fossil_nstream_t *ns, int backlog);
+int fossil_nstream_connect(fossil_nstream_t *stream, const char *host, int port);
 
 /**
- * Accept a new incoming connection on a listening socket. This function
- * extracts the first connection request on the queue of pending connections
- * and creates a new socket for the connection.
- * 
- * @param ns The listening network stream.
- * @return A valid network stream for the new connection on success, or NULL on failure.
+ * Set up a network stream to listen for incoming connections.
+ *
+ * @param stream The network stream to set up.
+ * @param host The hostname or IP address to bind to.
+ * @param port The port number to listen on.
+ * @return 0 on success, or -1 on failure.
  */
-fossil_nstream_t *fossil_nstream_accept(fossil_nstream_t *ns);
+int fossil_nstream_listen(fossil_nstream_t *stream, const char *host, int port);
 
 /**
- * Close the network stream. This function releases the resources associated with the
- * network stream and closes the connection.
- * 
- * @param ns The network stream to close.
+ * Accept a new incoming connection on a listening network stream.
+ *
+ * @param server The listening network stream.
+ * @return A pointer to the new network stream for the accepted connection, or NULL on failure.
  */
-void fossil_nstream_close(fossil_nstream_t *ns);
+fossil_nstream_t *fossil_nstream_accept(fossil_nstream_t *server);
 
 /**
- * Set the socket to non-blocking mode.
- * 
- * @param ns The network stream to modify.
- * @param enable 1 to enable non-blocking mode, 0 to disable it.
- * @return 0 on success, -1 on failure.
- */
-int fossil_nstream_set_nonblocking(fossil_nstream_t *ns, int enable);
-
-/**
- * Wait for the socket to become readable.
- * 
- * @param ns The network stream to wait on.
- * @param timeout_ms The timeout in milliseconds.
- * @return 0 on success, -1 on failure, or 1 if the timeout occurred.
- */
-int fossil_nstream_wait_readable(fossil_nstream_t *ns, int timeout_ms);
-
-/**
- * Wait for the socket to become writable.
- * 
- * @param ns The network stream to wait on.
- * @param timeout_ms The timeout in milliseconds.
- * @return 0 on success, -1 on failure, or 1 if the timeout occurred.
- */
-int fossil_nstream_wait_writable(fossil_nstream_t *ns, int timeout_ms);
-
-/**
- * Connect to a remote server. This function establishes a connection to a
- * specified IP address and port.
- * 
- * @param ns The network stream to use for the connection.
- * @param host The hostname or IP address of the remote server.
- * @param port The port number of the remote server.
- * @param timeout_ms The timeout in milliseconds.
- * @return 0 on success, -1 on failure.
- */
-int fossil_nstream_connect_timeout(fossil_nstream_t *ns, const char *host, const char *port, int timeout_ms);
-
-/**
- * Get the IP address and port of the connected peer.
- * 
- * @param ns The network stream to query.
- * @param ip_str A buffer to store the IP address as a string.
- * @param ip_len The length of the IP address buffer.
- * @param port A pointer to store the port number.
- * @return 0 on success, -1 on failure.
- */
-int fossil_nstream_get_peer_info(fossil_nstream_t *ns, char *ip_str, size_t ip_len, uint16_t *port);
-
-/**
- * Get the local IP address and port of the socket.
- * 
- * @param ns The network stream to query.
- * @param ip_str A buffer to store the local IP address as a string.
- * @param ip_len The length of the IP address buffer.
- * @param port A pointer to store the local port number.
- * @return 0 on success, -1 on failure.
- */
-ssize_t fossil_nstream_send_line(fossil_nstream_t *ns, const char *line);
-
-/**
- * Receive a line of text from the network stream. This function reads data
- * until a newline character is encountered.
- * 
- * @param ns The network stream to receive data from.
- * @param buf The buffer to store the received line.
- * @param max_len The maximum length of the buffer.
- * @return The number of bytes received, or -1 on failure.
- */
-ssize_t fossil_nstream_recv_line(fossil_nstream_t *ns, char *buf, size_t max_len);
-
-/**
- * Send data over a TLS connection.
- * 
- * @param ns The network stream to send data through.
- * @param buf The buffer containing the data to send.
- * @param len The length of the data to send.
+ * Send data through a network stream.
+ *
+ * @param stream The network stream to send data through.
+ * @param buffer The buffer containing the data to send.
+ * @param size The size of the data to send, in bytes.
  * @return The number of bytes sent, or -1 on failure.
  */
-ssize_t fossil_nstream_ssl_send(fossil_nstream_t *ns, const void *buf, size_t len);
+ssize_t fossil_nstream_send(fossil_nstream_t *stream, const void *buffer, size_t size);
 
 /**
- * Receive data over a TLS connection.
- * 
- * @param ns The network stream to receive data from.
- * @param buf The buffer to store the received data.
- * @param len The maximum length of data to receive.
+ * Receive data through a network stream.
+ *
+ * @param stream The network stream to receive data from.
+ * @param buffer The buffer to store the received data.
+ * @param size The maximum size of the buffer, in bytes.
  * @return The number of bytes received, or -1 on failure.
  */
-ssize_t fossil_nstream_ssl_recv(fossil_nstream_t *ns, void *buf, size_t len);
+ssize_t fossil_nstream_recv(fossil_nstream_t *stream, void *buffer, size_t size);
 
 /**
- * Send data over a UDP socket.
- * 
- * @param ns The network stream to send data through.
- * @param buf The buffer containing the data to send.
- * @param len The length of the data to send.
- * @param ip The IP address of the destination.
- * @param port The port number of the destination.
- * @return The number of bytes sent, or -1 on failure.
+ * Close a network stream.
+ *
+ * @param stream The network stream to close.
  */
-const char *fossil_nstream_strerror(void);
+void fossil_nstream_close(fossil_nstream_t *stream);
+
+/**
+ * Destroy a network stream and free its resources.
+ *
+ * @param stream The network stream to destroy.
+ */
+void fossil_nstream_destroy(fossil_nstream_t *stream);
+
+/**
+ * Get a string describing the last error that occurred.
+ *
+ * @return A string describing the last error.
+ */
+const char *fossil_nstream_last_error(void);
 
 #ifdef __cplusplus
 }
+#include <stdexcept>
 #include <string>
 
 /**
@@ -216,174 +149,123 @@ namespace fossil {
         /**
          * Class for network operations.
          */
+        /**
+         * A C++ wrapper class for the Fossil network stream API.
+         * Provides an object-oriented interface for managing network streams.
+         */
         class NStream {
         public:
-
             /**
-             * Constructor for NStream.
-             * 
-             * @param protocol The protocol to use (e.g., "tcp", "udp").
-             * @param host The hostname or IP address.
-             * @param port The port number.
-             * @param flags Additional flags (e.g., "server").
+             * Constructor to create a new network stream.
+             *
+             * @param protocol_flag The protocol to use (e.g., "tcp", "udp").
+             * @param client_type_flag The type of client (e.g., "server", "client").
+             * @throws std::runtime_error If the stream creation fails.
              */
-            NStream(const std::string &protocol, const std::string &host, const std::string &port, const std::string &flags) {
-                ns = fossil_nstream_open(protocol.c_str(), host.c_str(), port.c_str(), flags.c_str());
+            NStream(const std::string &protocol_flag, const std::string &client_type_flag) {
+                stream_ = fossil_nstream_create(protocol_flag.c_str(), client_type_flag.c_str());
+                if (!stream_) {
+                    throw std::runtime_error(fossil_nstream_last_error());
+                }
             }
 
             /**
-             * Constructor for NStream with an existing socket.
-             * 
-             * @param socket The existing socket file descriptor.
+             * Destructor to destroy the network stream and free its resources.
              */
             ~NStream() {
-                if (ns) {
-                    fossil_nstream_close(ns);
+                if (stream_) {
+                    fossil_nstream_destroy(stream_);
                 }
+            }
+
+            /**
+             * Connect the network stream to a remote host.
+             *
+             * @param host The hostname or IP address of the remote host.
+             * @param port The port number to connect to.
+             * @throws std::runtime_error If the connection fails.
+             */
+            void connect(const std::string &host, int port) {
+                if (fossil_nstream_connect(stream_, host.c_str(), port) != 0) {
+                    throw std::runtime_error(fossil_nstream_last_error());
+                }
+            }
+
+            /**
+             * Set up the network stream to listen for incoming connections.
+             *
+             * @param host The hostname or IP address to bind to.
+             * @param port The port number to listen on.
+             * @throws std::runtime_error If the setup fails.
+             */
+            void listen(const std::string &host, int port) {
+                if (fossil_nstream_listen(stream_, host.c_str(), port) != 0) {
+                    throw std::runtime_error(fossil_nstream_last_error());
+                }
+            }
+
+            /**
+             * Accept a new incoming connection on a listening network stream.
+             *
+             * @return A pointer to a new NStream object for the accepted connection.
+             * @throws std::runtime_error If accepting the connection fails.
+             */
+            NStream *accept() {
+                fossil_nstream_t *accepted_stream = fossil_nstream_accept(stream_);
+                if (!accepted_stream) {
+                    throw std::runtime_error(fossil_nstream_last_error());
+                }
+                return new NStream(accepted_stream);
             }
 
             /**
              * Send data through the network stream.
              *
-             * @param buf The buffer containing the data to send.
-             * @param len The length of the data to send.
-             * @return The number of bytes sent, or -1 on failure.
+             * @param buffer The buffer containing the data to send.
+             * @param size The size of the data to send, in bytes.
+             * @return The number of bytes sent.
+             * @throws std::runtime_error If sending the data fails.
              */
-            ssize_t send(const void *buf, size_t len) {
-                return fossil_nstream_send(ns, buf, len);
+            ssize_t send(const void *buffer, size_t size) {
+                ssize_t bytes_sent = fossil_nstream_send(stream_, buffer, size);
+                if (bytes_sent < 0) {
+                    throw std::runtime_error(fossil_nstream_last_error());
+                }
+                return bytes_sent;
             }
 
             /**
              * Receive data through the network stream.
-             * 
-             * @param buf The buffer to store the received data.
-             * @param len The maximum length of data to receive.
-             * @return The number of bytes received, or -1 on failure.
-             */
-            ssize_t recv(void *buf, size_t len) {
-                return fossil_nstream_recv(ns, buf, len);
-            }
-
-            /**
-             * Listen on a network stream (for servers).
              *
-             * @param backlog The maximum length of the queue of pending connections.
-             * @return 0 on success, -1 on failure.
+             * @param buffer The buffer to store the received data.
+             * @param size The maximum size of the buffer, in bytes.
+             * @return The number of bytes received.
+             * @throws std::runtime_error If receiving the data fails.
              */
-            int listen(int backlog) {
-                return fossil_nstream_listen(ns, backlog);
-            }
-
-            /**
-             * Accept a new incoming connection on a listening socket.
-             * 
-             * @return A valid network stream for the new connection on success, or nullptr on failure.
-             */
-            NStream *accept() {
-                fossil_nstream_t *new_ns = fossil_nstream_accept(ns);
-                return new_ns ? new NStream(new_ns) : nullptr;
-            }
-
-            /**
-             * Set the socket to non-blocking mode.
-             * 
-             * @param enable 1 to enable non-blocking mode, 0 to disable it.
-             * @return 0 on success, -1 on failure.
-             */
-            int set_non_blocking(int enable) {
-                return fossil_nstream_set_nonblocking(ns, enable);
-            }
-
-            /**
-             * Wait for the socket to become readable.
-             * 
-             * @param timeout_ms The timeout in milliseconds.
-             * @return 0 on success, -1 on failure, or 1 if the timeout occurred.
-             */
-            int wait_readable(int timeout_ms) {
-                return fossil_nstream_wait_readable(ns, timeout_ms);
-            }
-
-            /**
-             * Wait for the socket to become writable.
-             * 
-             * @param timeout_ms The timeout in milliseconds.
-             * @return 0 on success, -1 on failure, or 1 if the timeout occurred.
-             */
-            int wait_writable(int timeout_ms) {
-                return fossil_nstream_wait_writable(ns, timeout_ms);
-            }
-
-            /**
-             * Connect to a remote server with a timeout.
-             * 
-             * @param host The hostname or IP address of the remote server.
-             * @param port The port number of the remote server.
-             * @param timeout_ms The timeout in milliseconds.
-             * @return 0 on success, -1 on failure.
-             */
-            int connect_timeout(const std::string &host, const std::string &port, int timeout_ms) {
-                return fossil_nstream_connect_timeout(ns, host.c_str(), port.c_str(), timeout_ms);
-            }
-
-            /**
-             * Get the IP address and port of the connected peer.
-             * 
-             * @param ip_str A string to store the IP address.
-             * @param port A reference to store the port number.
-             * @return 0 on success, -1 on failure.
-             */
-            int get_peer_info(std::string &ip_str, uint16_t &port) {
-                char ip_buf[INET_ADDRSTRLEN];
-                int result = fossil_nstream_get_peer_info(ns, ip_buf, sizeof(ip_buf), &port);
-                if (result == 0) {
-                    ip_str = ip_buf;
+            ssize_t recv(void *buffer, size_t size) {
+                ssize_t bytes_received = fossil_nstream_recv(stream_, buffer, size);
+                if (bytes_received < 0) {
+                    throw std::runtime_error(fossil_nstream_last_error());
                 }
-                return result;
+                return bytes_received;
             }
 
             /**
-             * Send a line of text through the network stream.
-             * 
-             * @param line The line of text to send.
-             * @return The number of bytes sent, or -1 on failure.
+             * Close the network stream.
              */
-            ssize_t send_line(const std::string &line) {
-                return fossil_nstream_send_line(ns, line.c_str());
-            }
-
-            /**
-             * Receive a line of text from the network stream.
-             * 
-             * @param buf A string to store the received line.
-             * @param max_len The maximum length of the buffer.
-             * @return The number of bytes received, or -1 on failure.
-             */
-            ssize_t recv_line(std::string &buf, size_t max_len) {
-                char *temp_buf = new char[max_len];
-                ssize_t result = fossil_nstream_recv_line(ns, temp_buf, max_len);
-                if (result >= 0) {
-                    buf.assign(temp_buf, result);
-                }
-                delete[] temp_buf;
-                return result;
-            }
-
-            /**
-             * Get a string describing the last error.
-             * 
-             * @return A string describing the last error.
-             */
-            const char *str_error() {
-                return fossil_nstream_strerror();
+            void close() {
+                fossil_nstream_close(stream_);
             }
 
         private:
-            fossil_nstream_t *ns;
+            /**
+             * Private constructor to wrap an existing fossil_nstream_t object.
+             *
+             * @param stream A pointer to an existing fossil_nstream_t object.
+             */
+            NStream(fossil_nstream_t *stream) : stream_(stream) {}
 
-            // Private constructor for internal use
-            NStream(fossil_nstream_t *existing_ns) : ns(existing_ns) {}
-
+            fossil_nstream_t *stream_; /**< Pointer to the underlying network stream. */
         };
     }
 }

--- a/code/logic/fossil/io/network.h
+++ b/code/logic/fossil/io/network.h
@@ -20,6 +20,7 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #else
+#include <sys/select.h>  // For fd_set and select
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/code/logic/network.c
+++ b/code/logic/network.c
@@ -52,7 +52,7 @@ const char *fossil_nstream_last_error(void) {
     return fossil_last_error;
 }
 
-static int fossil_socket_init() {
+static int fossil_socket_init(void) {
 #ifdef _WIN32
     WSADATA wsa;
     return WSAStartup(MAKEWORD(2,2), &wsa);
@@ -61,7 +61,7 @@ static int fossil_socket_init() {
 #endif
 }
 
-static void fossil_socket_cleanup() {
+static void fossil_socket_cleanup(void) {
 #ifdef _WIN32
     WSACleanup();
 #endif
@@ -246,7 +246,7 @@ int fossil_nstream_listen(fossil_nstream_t *stream, const char *host, int port) 
     }
     
     stream->socket_fd = fossil_create_socket(stream->protocol);
-    if (stream->socket_fd < 0) {
+    if (stream->socket_fd == (socket_t)-1) {
         return -1;
     }
     
@@ -332,7 +332,7 @@ ssize_t fossil_nstream_send(fossil_nstream_t *stream, const void *buffer, size_t
 }
 
 ssize_t fossil_nstream_recv(fossil_nstream_t *stream, void *buffer, size_t size) {
-    if (!stream || stream->socket_fd < 0) {
+    if (!stream || stream->socket_fd == (socket_t)-1) {
         fossil_set_last_error("Invalid stream or socket");
         return -1;
     }
@@ -348,7 +348,7 @@ ssize_t fossil_nstream_recv(fossil_nstream_t *stream, void *buffer, size_t size)
 }
 
 void fossil_nstream_close(fossil_nstream_t *stream) {
-    if (!stream || (socket_t)(stream->socket_fd) < 0) return;
+    if (!stream || stream->socket_fd == (socket_t)-1) return;
 #ifdef _WIN32
     closesocket(stream->socket_fd);
 #else

--- a/code/logic/network.c
+++ b/code/logic/network.c
@@ -13,6 +13,7 @@
  */
 #include "fossil/io/network.h"
 #include <stdio.h>
+#include <string.h>
 #include <sys/select.h>  // For fd_set and select
 #include <sys/time.h>    // For struct timeval
 #include <unistd.h>      // For close on POSIX systems

--- a/code/logic/network.c
+++ b/code/logic/network.c
@@ -217,7 +217,7 @@ int fossil_nstream_connect(fossil_nstream_t *stream, const char *host, int port)
     }
     
     stream->socket_fd = fossil_create_socket(stream->protocol);
-    if (stream->socket_fd < 0) {
+    if ((int)stream->socket_fd < 0) {
         return -1;
     }
     
@@ -285,7 +285,7 @@ fossil_nstream_t *fossil_nstream_accept(fossil_nstream_t *server) {
     socklen_t addrlen = sizeof(addr);
 
     socket_t client_fd = accept(server->socket_fd, (struct sockaddr *)&addr, &addrlen);
-    if (client_fd < 0) {
+    if ((int)client_fd < 0) {
 #ifdef _WIN32
         if (WSAGetLastError() != WSAEWOULDBLOCK) {
 #else
@@ -316,7 +316,7 @@ fossil_nstream_t *fossil_nstream_accept(fossil_nstream_t *server) {
 }
 
 ssize_t fossil_nstream_send(fossil_nstream_t *stream, const void *buffer, size_t size) {
-    if (!stream || stream->socket_fd < 0) {
+    if (!stream || (int)stream->socket_fd < 0) {
         fossil_set_last_error("Invalid stream or socket");
         return -1;
     }
@@ -348,7 +348,7 @@ ssize_t fossil_nstream_recv(fossil_nstream_t *stream, void *buffer, size_t size)
 }
 
 void fossil_nstream_close(fossil_nstream_t *stream) {
-    if (!stream || stream->socket_fd < 0) return;
+    if (!stream || (socket_t)(stream->socket_fd) < 0) return;
 #ifdef _WIN32
     closesocket(stream->socket_fd);
 #else

--- a/code/logic/network.c
+++ b/code/logic/network.c
@@ -13,189 +13,342 @@
  */
 #include "fossil/io/network.h"
 #include <stdio.h>
-#include <string.h>
-#include <errno.h>  // For POSIX error handling
-#include <stdlib.h> // For exit()
+#include <sys/select.h>  // For fd_set and select
+#include <sys/time.h>    // For struct timeval
+#include <unistd.h>      // For close on POSIX systems
 
 #ifdef _WIN32
-    static WSADATA wsa;
-#endif
-
-int fossil_io_network_create(void) {
-#ifdef _WIN32
-    return WSAStartup(MAKEWORD(2, 2), &wsa);
+#define close_socket(s) closesocket(s)
 #else
-    return 0; // No initialization needed on Unix-like systems
+#define close_socket(s) close(s)
 #endif
+
+// Helper function to resolve the port number
+static int resolve_port(const char *port_str) {
+    return atoi(port_str);
 }
 
-void fossil_io_network_destroy(void) {
-#ifdef _WIN32
-    WSACleanup();
-#endif
-}
+// Initialize socket (for both client and server)
+static int init_socket(const char *protocol) {
+    int sock = -1;
 
-fossil_io_socket_t fossil_io_network_create_socket(int type) {
-    fossil_io_socket_t sock = socket(AF_INET, type, 0);
-    if (sock == FOSSIL_IO_INVALID_SOCKET) {
-#ifdef _WIN32
-        fprintf(stderr, "Socket creation failed with error: %d\n", WSAGetLastError());
-#else
-        perror("Socket creation failed");
-#endif
+    if (strcmp(protocol, "tcp") == 0) {
+        sock = socket(AF_INET, SOCK_STREAM, 0);
+    } else if (strcmp(protocol, "udp") == 0) {
+        sock = socket(AF_INET, SOCK_DGRAM, 0);
+    } else if (strcmp(protocol, "raw") == 0) {
+        sock = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
+    } else if (strcmp(protocol, "icmp") == 0) {
+        sock = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+    } else {
+        return -1;  // Unsupported protocol
     }
+
     return sock;
 }
 
-int fossil_io_network_bind(fossil_io_socket_t sock, const char *ip, uint16_t port) {
-    struct sockaddr_in addr;
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = ip ? inet_addr(ip) : INADDR_ANY;
+// Open a new network stream (TCP/UDP)
+fossil_nstream_t *fossil_nstream_open(const char *protocol, const char *host, const char *port, const char *flags) {
+    fossil_nstream_t *ns = malloc(sizeof(fossil_nstream_t));
+    if (!ns) return NULL;
 
-    if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
-#ifdef _WIN32
-        fprintf(stderr, "Bind failed with error: %d\n", WSAGetLastError());
-#else
-        perror("Bind failed");
-#endif
-        return -1;
+    ns->socket = init_socket(protocol);
+    if (ns->socket < 0) {
+        free(ns);
+        return NULL;
     }
-    return 0;
+
+    ns->is_tls = (flags && strstr(flags, "tls") != NULL);  // Check if we need TLS (simplified)
+
+    memset(&ns->addr, 0, sizeof(ns->addr));
+    ns->addr.sin_family = AF_INET;
+    ns->addr.sin_port = htons(resolve_port(port));
+#ifdef _WIN32
+    ns->addr.sin_addr.s_addr = inet_addr(host);
+#else
+    if (inet_pton(AF_INET, host, &ns->addr.sin_addr) <= 0) {
+        close_socket(ns->socket);
+        free(ns);
+        return NULL;
+    }
+#endif
+
+    strncpy(ns->protocol, protocol, sizeof(ns->protocol) - 1);
+    ns->protocol[sizeof(ns->protocol) - 1] = '\0';
+
+    // Optionally bind socket for server
+    if (flags && strstr(flags, "server") != NULL) {
+        if (bind(ns->socket, (struct sockaddr *)&ns->addr, sizeof(ns->addr)) < 0) {
+            close_socket(ns->socket);
+            free(ns);
+            return NULL;
+        }
+    }
+
+    return ns;
 }
 
-int fossil_io_network_listen(fossil_io_socket_t sock, int backlog) {
-    if (listen(sock, backlog) == -1) {
-#ifdef _WIN32
-        fprintf(stderr, "Listen failed with error: %d\n", WSAGetLastError());
-#else
-        perror("Listen failed");
-#endif
-        return -1;
+// Send data through the network stream
+ssize_t fossil_nstream_send(fossil_nstream_t *ns, const void *buf, size_t len) {
+    if (strcmp(ns->protocol, "udp") == 0) {
+        return sendto(ns->socket, buf, len, 0, (struct sockaddr *)&ns->addr, sizeof(ns->addr));
+    } else if (strcmp(ns->protocol, "raw") == 0 || strcmp(ns->protocol, "icmp") == 0) {
+        return sendto(ns->socket, buf, len, 0, (struct sockaddr *)&ns->addr, sizeof(ns->addr));
     }
-    return 0;
+    return send(ns->socket, buf, len, 0);
 }
 
-fossil_io_socket_t fossil_io_network_accept(fossil_io_socket_t sock, char *client_ip, uint16_t *client_port) {
+// Receive data through the network stream
+ssize_t fossil_nstream_recv(fossil_nstream_t *ns, void *buf, size_t len) {
+    if (strcmp(ns->protocol, "udp") == 0) {
+        socklen_t addr_len = sizeof(ns->addr);
+        return recvfrom(ns->socket, buf, len, 0, (struct sockaddr *)&ns->addr, &addr_len);
+    } else if (strcmp(ns->protocol, "raw") == 0 || strcmp(ns->protocol, "icmp") == 0) {
+        socklen_t addr_len = sizeof(ns->addr);
+        return recvfrom(ns->socket, buf, len, 0, (struct sockaddr *)&ns->addr, &addr_len);
+    }
+    return recv(ns->socket, buf, len, 0);
+}
+
+// Listen on a network stream (for servers)
+int fossil_nstream_listen(fossil_nstream_t *ns, int backlog) {
+    if (strcmp(ns->protocol, "tcp") == 0) {
+        return listen(ns->socket, backlog);
+    }
+    return -1;  // Listen only supports TCP
+}
+
+// Accept an incoming connection on a server
+fossil_nstream_t *fossil_nstream_accept(fossil_nstream_t *ns) {
     struct sockaddr_in client_addr;
     socklen_t addr_len = sizeof(client_addr);
-    fossil_io_socket_t client_sock = accept(sock, (struct sockaddr*)&client_addr, &addr_len);
+    int client_sock = accept(ns->socket, (struct sockaddr *)&client_addr, &addr_len);
+    
+    if (client_sock < 0) return NULL;
 
-    if (client_sock == FOSSIL_IO_INVALID_SOCKET) {
+    fossil_nstream_t *client_ns = malloc(sizeof(fossil_nstream_t));
+    if (!client_ns) return NULL;
+
+    client_ns->socket = client_sock;
+    client_ns->addr = client_addr;
+    strcpy(client_ns->protocol, ns->protocol);  // Inherit protocol from server
+
+    return client_ns;
+}
+
+// Close the network stream
+void fossil_nstream_close(fossil_nstream_t *ns) {
+    close_socket(ns->socket);
+    free(ns);
+}
+
+// Set socket to non-blocking mode
+int fossil_nstream_set_nonblocking(fossil_nstream_t *ns, int enable) {
 #ifdef _WIN32
-        fprintf(stderr, "Accept failed with error: %d\n", WSAGetLastError());
+    u_long mode = enable ? 1 : 0;
+    return ioctlsocket(ns->socket, FIONBIO, &mode);
 #else
-        perror("Accept failed");
+    int flags = fcntl(ns->socket, F_GETFL, 0);
+    if (flags == -1) {
+        return -1;
+    }
+
+    if (enable) {
+        flags |= O_NONBLOCK;
+    } else {
+        flags &= ~O_NONBLOCK;
+    }
+
+    return fcntl(ns->socket, F_SETFL, flags);
 #endif
-    } else if (client_ip) {
-        strcpy(client_ip, inet_ntoa(client_addr.sin_addr));
-        if (client_port) {
-            *client_port = ntohs(client_addr.sin_port);
+}
+
+// Send a line of text (appends \r\n)
+ssize_t fossil_nstream_send_line(fossil_nstream_t *ns, const char *line) {
+    size_t len = strlen(line);
+    char *buffer = malloc(len + 3);
+    if (!buffer) return -1;
+
+    strcpy(buffer, line);
+    buffer[len] = '\r';
+    buffer[len + 1] = '\n';
+    buffer[len + 2] = '\0';
+
+    ssize_t result = fossil_nstream_send(ns, buffer, len + 2);
+    free(buffer);
+    return result;
+}
+
+// Receive a line (stops at \r\n or max_len)
+ssize_t fossil_nstream_recv_line(fossil_nstream_t *ns, char *buf, size_t max_len) {
+    ssize_t total_received = 0;
+    char c;
+    size_t i = 0;
+
+    while (i < max_len - 1) {
+        ssize_t result = fossil_nstream_recv(ns, &c, 1);
+        if (result <= 0) {
+#ifdef _WIN32
+            if (WSAGetLastError() == WSAEWOULDBLOCK) {
+                continue;  // Non-blocking mode, retry
+            }
+#else
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                continue;  // Non-blocking mode, retry
+            }
+#endif
+            return result;
+        }
+
+        buf[i++] = c;
+        total_received++;
+
+        // Stop when \r\n is found
+        if (i >= 2 && buf[i-1] == '\n' && buf[i-2] == '\r') {
+            break;
         }
     }
 
-    return client_sock;
+    buf[i] = '\0';  // Null-terminate the buffer
+    return total_received;
 }
 
-int fossil_io_network_connect(fossil_io_socket_t sock, const char *ip, uint16_t port) {
+// Set socket to non-blocking mode
+int fossil_nstream_set_nonblocking(fossil_nstream_t *ns, int enable) {
+#ifdef _WIN32
+    u_long mode = enable ? 1 : 0;
+    return ioctlsocket(ns->socket, FIONBIO, &mode);
+#else
+    int flags = fcntl(ns->socket, F_GETFL, 0);
+    if (flags == -1) return -1;
+
+    if (enable) {
+        flags |= O_NONBLOCK;
+    } else {
+        flags &= ~O_NONBLOCK;
+    }
+
+    return fcntl(ns->socket, F_SETFL, flags);
+#endif
+}
+
+// Wait for the socket to become readable
+int fossil_nstream_wait_readable(fossil_nstream_t *ns, int timeout_ms) {
+    struct timeval timeout;
+    timeout.tv_sec = timeout_ms / 1000;
+    timeout.tv_usec = (timeout_ms % 1000) * 1000;
+
+    fd_set readfds;
+    FD_ZERO(&readfds);
+    FD_SET(ns->socket, &readfds);
+
+    return select(ns->socket + 1, &readfds, NULL, NULL, &timeout);
+}
+
+// Wait for the socket to become writable
+int fossil_nstream_wait_writable(fossil_nstream_t *ns, int timeout_ms) {
+    struct timeval timeout;
+    timeout.tv_sec = timeout_ms / 1000;
+    timeout.tv_usec = (timeout_ms % 1000) * 1000;
+
+    fd_set writefds;
+    FD_ZERO(&writefds);
+    FD_SET(ns->socket, &writefds);
+
+    return select(ns->socket + 1, NULL, &writefds, NULL, &timeout);
+}
+
+// Connect with timeout
+int fossil_nstream_connect_timeout(fossil_nstream_t *ns, const char *host, const char *port, int timeout_ms) {
     struct sockaddr_in server_addr;
     server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port);
-    server_addr.sin_addr.s_addr = inet_addr(ip);
+    server_addr.sin_port = htons(resolve_port(port));
+    server_addr.sin_addr.s_addr = inet_addr(host);
 
-    if (connect(sock, (struct sockaddr*)&server_addr, sizeof(server_addr)) == -1) {
+    // Set socket to non-blocking
+    fossil_nstream_set_nonblocking(ns, 1);
+
+    int result = connect(ns->socket, (struct sockaddr *)&server_addr, sizeof(server_addr));
+
+    if (result < 0) {
 #ifdef _WIN32
-        fprintf(stderr, "Connect failed with error: %d\n", WSAGetLastError());
+        if (WSAGetLastError() == WSAEWOULDBLOCK) {
 #else
-        perror("Connect failed");
+        if (errno == EINPROGRESS) {
 #endif
-        return -1;
+            struct timeval timeout;
+            timeout.tv_sec = timeout_ms / 1000;
+            timeout.tv_usec = (timeout_ms % 1000) * 1000;
+
+            fd_set writefds;
+            FD_ZERO(&writefds);
+            FD_SET(ns->socket, &writefds);
+
+            result = select(ns->socket + 1, NULL, &writefds, NULL, &timeout);
+            if (result <= 0) return -1;  // Timeout or error
+        } else {
+            return -1;  // Immediate error
+        }
     }
+
+    // Set socket back to blocking
+    fossil_nstream_set_nonblocking(ns, 0);
+
     return 0;
 }
 
-int fossil_io_network_send(fossil_io_socket_t sock, const void *data, size_t len) {
-    int bytes_sent = send(sock, data, (int)len, 0);
-    if (bytes_sent == -1) {
-#ifdef _WIN32
-        fprintf(stderr, "Send failed with error: %d\n", WSAGetLastError());
-#else
-        perror("Send failed");
-#endif
-    }
-    return bytes_sent;
+// Get peer information (client's IP and port)
+int fossil_nstream_get_peer_info(fossil_nstream_t *ns, char *ip_str, size_t ip_len, uint16_t *port) {
+    struct sockaddr_in peer_addr;
+    socklen_t addr_len = sizeof(peer_addr);
+    if (getpeername(ns->socket, (struct sockaddr *)&peer_addr, &addr_len) == -1) return -1;
+
+    inet_ntop(AF_INET, &peer_addr.sin_addr, ip_str, ip_len);
+    *port = ntohs(peer_addr.sin_port);
+    return 0;
 }
 
-int fossil_io_network_receive(fossil_io_socket_t sock, void *buffer, size_t len) {
-    int bytes_received = recv(sock, buffer, (int)len, 0);
-    if (bytes_received == -1) {
-#ifdef _WIN32
-        fprintf(stderr, "Receive failed with error: %d\n", WSAGetLastError());
-#else
-        perror("Receive failed");
-#endif
+// Send a line (e.g., for SMTP/IMAP)
+ssize_t fossil_nstream_send_line(fossil_nstream_t *ns, const char *line) {
+    size_t len = strlen(line);
+    char *buffer = malloc(len + 3);  // \r\n
+    if (!buffer) return -1;
+
+    sprintf(buffer, "%s\r\n", line);
+    ssize_t result = fossil_nstream_send(ns, buffer, len + 2);
+
+    free(buffer);
+    return result;
+}
+
+// Receive a line (e.g., for SMTP/IMAP)
+ssize_t fossil_nstream_recv_line(fossil_nstream_t *ns, char *buf, size_t max_len) {
+    ssize_t bytes_received = 0;
+    char ch;
+    while (bytes_received < max_len - 1) {
+        if (fossil_nstream_recv(ns, &ch, 1) <= 0) return -1;
+
+        buf[bytes_received++] = ch;
+        if (ch == '\n') break;
     }
+
+    buf[bytes_received] = '\0';
     return bytes_received;
 }
 
-int fossil_io_network_sendto(fossil_io_socket_t sock, const void *data, size_t len, const char *ip, uint16_t port) {
-    struct sockaddr_in dest_addr;
-    dest_addr.sin_family = AF_INET;
-    dest_addr.sin_port = htons(port);
-    dest_addr.sin_addr.s_addr = inet_addr(ip);
-
-    int bytes_sent = sendto(sock, data, (int)len, 0, (struct sockaddr*)&dest_addr, sizeof(dest_addr));
-    if (bytes_sent == -1) {
-#ifdef _WIN32
-        fprintf(stderr, "Sendto failed with error: %d\n", WSAGetLastError());
-#else
-        perror("Sendto failed");
-#endif
-    }
-    return bytes_sent;
+// SSL/TLS send wrapper
+ssize_t fossil_nstream_ssl_send(fossil_nstream_t *ns, const void *buf, size_t len) {
+    // TLS handling code here (simplified for now)
+    return send(ns->socket, buf, len, 0);
 }
 
-int fossil_io_network_recvfrom(fossil_io_socket_t sock, void *buffer, size_t len, char *ip, uint16_t *port) {
-    struct sockaddr_in src_addr;
-    socklen_t addr_len = sizeof(src_addr);
-
-    int bytes_received = recvfrom(sock, buffer, (int)len, 0, (struct sockaddr*)&src_addr, &addr_len);
-    if (bytes_received == -1) {
-#ifdef _WIN32
-        fprintf(stderr, "Recvfrom failed with error: %d\n", WSAGetLastError());
-#else
-        perror("Recvfrom failed");
-#endif
-    } else if (ip) {
-        strcpy(ip, inet_ntoa(src_addr.sin_addr));
-        if (port) {
-            *port = ntohs(src_addr.sin_port);
-        }
-    }
-    return bytes_received;
+// SSL/TLS receive wrapper
+ssize_t fossil_nstream_ssl_recv(fossil_nstream_t *ns, void *buf, size_t len) {
+    // TLS handling code here (simplified for now)
+    return recv(ns->socket, buf, len, 0);
 }
 
-void fossil_io_network_close(fossil_io_socket_t sock) {
-#ifdef _WIN32
-    if (closesocket(sock) == SOCKET_ERROR) {
-        fprintf(stderr, "Close socket failed with error: %d\n", WSAGetLastError());
-    }
-#else
-    if (close(sock) == -1) {
-        perror("Close socket failed");
-    }
-#endif
-}
-
-int fossil_io_network_bridge(fossil_io_socket_t sock1, fossil_io_socket_t sock2) {
-    char buffer[1024];
-    int bytes_received;
-
-    while ((bytes_received = fossil_io_network_receive(sock1, buffer, sizeof(buffer))) > 0) {
-        if (fossil_io_network_send(sock2, buffer, bytes_received) == -1) {
-            return -1;
-        }
-    }
-
-    return bytes_received;
+// Get the string representation of the last error
+const char *fossil_nstream_strerror(void) {
+    return strerror(errno);
 }

--- a/code/logic/network.c
+++ b/code/logic/network.c
@@ -15,7 +15,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/select.h>  // For fd_set and select
 #include <sys/time.h>    // For struct timeval
 #include <unistd.h>      // For close on POSIX systems
 

--- a/code/logic/network.c
+++ b/code/logic/network.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <sys/time.h>    // For struct timeval
 #include <unistd.h>      // For close on POSIX systems
 

--- a/code/logic/stream.c
+++ b/code/logic/stream.c
@@ -87,7 +87,7 @@ static const char *fossil_fstream_mode_from_keyword(const char *keyword) {
 int32_t fossil_fstream_open(fossil_fstream_t *stream, const char *filename, const char *mode) {
     if (stream == NULL || filename == NULL || mode == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     if (strlen(filename) >= FOSSIL_BUFFER_MEDIUM) {
@@ -119,7 +119,7 @@ void fossil_fstream_close(fossil_fstream_t *stream) {
 int32_t fossil_fstream_freopen(fossil_fstream_t *stream, const char *filename, const char *mode, FILE *file) {
     if (stream == NULL || filename == NULL || mode == NULL || file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     FILE *new_file = freopen(filename, fossil_fstream_mode_from_keyword(mode), file);
@@ -138,7 +138,7 @@ int32_t fossil_fstream_freopen(fossil_fstream_t *stream, const char *filename, c
 size_t fossil_fstream_read(fossil_fstream_t *stream, void *buffer, size_t size, size_t count) {
     if (stream == NULL || buffer == NULL || stream->file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     size_t bytes_read = fread(buffer, size, count, stream->file);
@@ -155,7 +155,7 @@ size_t fossil_fstream_read(fossil_fstream_t *stream, void *buffer, size_t size, 
 size_t fossil_fstream_write(fossil_fstream_t *stream, const void *buffer, size_t size, size_t count) {
     if (stream == NULL || buffer == NULL || stream->file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     size_t bytes_written = fwrite(buffer, size, count, stream->file);
@@ -172,7 +172,7 @@ size_t fossil_fstream_write(fossil_fstream_t *stream, const void *buffer, size_t
 int32_t fossil_fstream_append(fossil_fstream_t *stream, const void * restrict buffer, size_t size, int32_t count) {
     if (stream == NULL || buffer == NULL || stream->file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     fseek(stream->file, 0, SEEK_END);
@@ -190,7 +190,7 @@ int32_t fossil_fstream_append(fossil_fstream_t *stream, const void * restrict bu
 int32_t fossil_fstream_seek(fossil_fstream_t *stream, int64_t offset, int32_t origin) {
     if (stream == NULL || stream->file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     int32_t result = fseek(stream->file, offset, origin);
@@ -207,7 +207,7 @@ int32_t fossil_fstream_seek(fossil_fstream_t *stream, int64_t offset, int32_t or
 int32_t fossil_fstream_tell(fossil_fstream_t *stream) {
     if (stream == NULL || stream->file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     long position = ftell(stream->file);
@@ -224,7 +224,7 @@ int32_t fossil_fstream_tell(fossil_fstream_t *stream) {
 int32_t fossil_fstream_save(fossil_fstream_t *stream, const char *new_filename) {
     if (stream == NULL || stream->file == NULL || new_filename == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     if (strlen(new_filename) >= FOSSIL_BUFFER_MEDIUM) {
@@ -236,7 +236,7 @@ int32_t fossil_fstream_save(fossil_fstream_t *stream, const char *new_filename) 
 
     if (rename(stream->filename, new_filename) != 0) {
         fprintf(stderr, "Error: Failed to save %s\n", new_filename);
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     // Reopen the file with the new name
@@ -253,7 +253,7 @@ int32_t fossil_fstream_save(fossil_fstream_t *stream, const char *new_filename) 
 int32_t fossil_fstream_copy(const char *source_filename, const char *destination_filename) {
     if (source_filename == NULL || destination_filename == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     FILE *source_file = fopen(source_filename, "rb");
@@ -291,7 +291,7 @@ int32_t fossil_fstream_copy(const char *source_filename, const char *destination
 int32_t fossil_fstream_remove(const char *filename) {
     if (filename == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     if (remove(filename) == 0) {
@@ -305,7 +305,7 @@ int32_t fossil_fstream_remove(const char *filename) {
 int32_t fossil_fstream_rename(const char *old_filename, const char *new_filename) {
     if (old_filename == NULL || new_filename == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     if (rename(old_filename, new_filename) != 0) {
@@ -319,7 +319,7 @@ int32_t fossil_fstream_rename(const char *old_filename, const char *new_filename
 int32_t fossil_fstream_flush(fossil_fstream_t *stream) {
     if (stream == NULL || stream->file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     if (fflush(stream->file) != 0) {
@@ -333,7 +333,7 @@ int32_t fossil_fstream_flush(fossil_fstream_t *stream) {
 int32_t fossil_fstream_setpos(fossil_fstream_t *stream, int32_t pos) {
     if (stream == NULL || stream->file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     if (fseek(stream->file, pos, SEEK_SET) != 0) {
@@ -347,7 +347,7 @@ int32_t fossil_fstream_setpos(fossil_fstream_t *stream, int32_t pos) {
 int32_t fossil_fstream_getpos(fossil_fstream_t *stream, int32_t *pos) {
     if (stream == NULL || stream->file == NULL || pos == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     *pos = ftell(stream->file);
@@ -362,7 +362,7 @@ int32_t fossil_fstream_getpos(fossil_fstream_t *stream, int32_t *pos) {
 int32_t fossil_fstream_rotate(const char *filename, int32_t n) {
     if (filename == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     char old_filename[FOSSIL_BUFFER_MEDIUM];
@@ -389,7 +389,7 @@ int32_t fossil_fstream_rotate(const char *filename, int32_t n) {
 int32_t fossil_fstream_backup(const char *filename, const char *backup_suffix) {
     if (filename == NULL || backup_suffix == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     char backup_filename[FOSSIL_BUFFER_MEDIUM + 10];  // Length of backup_suffix + maximum integer length
@@ -407,7 +407,7 @@ int32_t fossil_fstream_backup(const char *filename, const char *backup_suffix) {
 int32_t fossil_fstream_file_exists(const char *filename) {
     if (filename == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     FILE *file = fopen(filename, "r");
@@ -422,7 +422,7 @@ int32_t fossil_fstream_file_exists(const char *filename) {
 int32_t fossil_fstream_get_size(fossil_fstream_t *stream) {
     if (stream == NULL || stream->file == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     fseek(stream->file, 0, SEEK_END);
@@ -441,7 +441,7 @@ int32_t fossil_fstream_get_size(fossil_fstream_t *stream) {
 int32_t fossil_fstream_delete(const char *filename) {
     if (filename == NULL) {
         fprintf(stderr, "Error: Null pointer\n");
-        return FOSSIL_ERROR_NULL_POINTER;
+        return FOSSIL_ERROR_CNULL_POINTER;
     }
 
     if (remove(filename) == 0) {

--- a/code/tests/cases/test_error.c
+++ b/code/tests/cases/test_error.c
@@ -48,8 +48,8 @@ FOSSIL_TEST_CASE(c_test_io_what_no_error) {
     ASSUME_ITS_EQUAL_CSTR("No error, operation successful.", result);
 }
 
-FOSSIL_TEST_CASE(c_test_io_what_null_pointer) {
-    const char *result = fossil_io_what(FOSSIL_ERROR_NULL_POINTER);
+FOSSIL_TEST_CASE(c_test_io_what_CNULL_pointer) {
+    const char *result = fossil_io_what(FOSSIL_ERROR_CNULL_POINTER);
     ASSUME_ITS_EQUAL_CSTR("Null pointer encountered.", result);
 }
 
@@ -204,7 +204,7 @@ FOSSIL_TEST_CASE(c_test_io_what_serialization_failed) {
 
 FOSSIL_TEST_GROUP(c_error_tests) {
     FOSSIL_TEST_ADD(c_error_suite, c_test_io_what_no_error);
-    FOSSIL_TEST_ADD(c_error_suite, c_test_io_what_null_pointer);
+    FOSSIL_TEST_ADD(c_error_suite, c_test_io_what_CNULL_pointer);
     FOSSIL_TEST_ADD(c_error_suite, c_test_io_what_invalid_argument);
     FOSSIL_TEST_ADD(c_error_suite, c_test_io_what_type_mismatch);
     FOSSIL_TEST_ADD(c_error_suite, c_test_io_what_invalid_operation);

--- a/code/tests/cases/test_error.cpp
+++ b/code/tests/cases/test_error.cpp
@@ -48,8 +48,8 @@ FOSSIL_TEST_CASE(cpp_test_io_what_no_error) {
     ASSUME_ITS_EQUAL_CSTR("No error, operation successful.", result);
 }
 
-FOSSIL_TEST_CASE(cpp_test_io_what_null_pointer) {
-    const char *result = fossil_io_what(FOSSIL_ERROR_NULL_POINTER);
+FOSSIL_TEST_CASE(cpp_test_io_what_CNULL_pointer) {
+    const char *result = fossil_io_what(FOSSIL_ERROR_CNULL_POINTER);
     ASSUME_ITS_EQUAL_CSTR("Null pointer encountered.", result);
 }
 
@@ -207,7 +207,7 @@ FOSSIL_TEST_CASE(cpp_test_io_error_exception_no_error) {
     }
 }
 
-FOSSIL_TEST_CASE(cpp_test_io_error_exception_null_pointer) {
+FOSSIL_TEST_CASE(cpp_test_io_error_exception_CNULL_pointer) {
     try {
         throw fossil::io::Error(fossil::io::ErrorCode::NULL_POINTER);
     } catch (const fossil::io::Error& e) {
@@ -483,7 +483,7 @@ FOSSIL_TEST_CASE(cpp_test_io_error_exception_serialization_failed) {
 
 FOSSIL_TEST_GROUP(cpp_error_tests) {
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_what_no_error);
-    FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_what_null_pointer);
+    FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_what_CNULL_pointer);
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_what_invalid_argument);
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_what_type_mismatch);
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_what_invalid_operation);
@@ -515,7 +515,7 @@ FOSSIL_TEST_GROUP(cpp_error_tests) {
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_what_serialization_failed);
 
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_error_exception_no_error);
-    FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_error_exception_null_pointer);
+    FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_error_exception_CNULL_pointer);
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_error_exception_invalid_argument);
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_error_exception_type_mismatch);
     FOSSIL_TEST_ADD(cpp_error_suite, cpp_test_io_error_exception_invalid_operation);

--- a/code/tests/cases/test_network.cpp
+++ b/code/tests/cases/test_network.cpp
@@ -248,7 +248,6 @@ FOSSIL_TEST_GROUP(cpp_network_tests) {
     FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_connect_timeout);
     FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_get_peer_info);
     FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_send_recv_line);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_ssl_send_recv);
 
     FOSSIL_TEST_REGISTER(cpp_network_suite);
 }

--- a/code/tests/cases/test_network.cpp
+++ b/code/tests/cases/test_network.cpp
@@ -12,218 +12,123 @@
  * -----------------------------------------------------------------------------
  */
 #include <fossil/test/framework.h>
-
 #include "fossil/io/framework.h"
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
-// * Fossil Logic Test Utilites
+// * Fossil Logic Test Utilities
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // Setup steps for things like test fixtures and
 // mock objects are set here.
 // * * * * * * * * * * * * * * * * * * * * * * * *
 
-// Define the test suite and add test cases
 FOSSIL_TEST_SUITE(cpp_network_suite);
 
 // Setup function for the test suite
 FOSSIL_SETUP(cpp_network_suite) {
-    // Setup code here
+    // Setup code (if needed)
 }
 
 // Teardown function for the test suite
 FOSSIL_TEARDOWN(cpp_network_suite) {
-    // Teardown code here
+    // Teardown code (if needed)
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // * Fossil Logic Test Cases
 // * * * * * * * * * * * * * * * * * * * * * * * *
-// The test cases below are provided as samples, inspired
-// by the Meson build system's approach of using test cases
-// as samples for library usage.
-// * * * * * * * * * * * * * * * * * * * * * * * *
 
-FOSSIL_TEST_CASE(cpp_test_nstream_open) {
-    fossil_nstream_t *ns = fossil_nstream_open("tcp", "127.0.0.1", "8080", NULL);
-    ASSUME_NOT_CNULL(ns);
-    fossil_nstream_close(ns);
+FOSSIL_TEST_CASE(cpp_test_nstream_create_and_destroy) {
+    const char *protocols[] = {"tcp", "udp", "raw", "icmp", "sctp", "http", "https", "ftp", "ssh", "dns", "ntp", "smtp", "pop3", "imap", "ldap", "mqtt"};
+    const char *clients[] = {"mail-server", "server", "mail-client", "client", "mail-bot", "bot", "multicast", "broadcast"};
+
+    for (size_t i = 0; i < sizeof(protocols) / sizeof(protocols[0]); i++) {
+        for (size_t j = 0; j < sizeof(clients) / sizeof(clients[0]); j++) {
+            fossil_nstream_t *stream = fossil_nstream_create(protocols[i], clients[j]);
+            ASSUME_NOT_CNULL(stream);
+            fossil_nstream_destroy(stream);
+        }
+    }
 }
 
-FOSSIL_TEST_CASE(cpp_test_nstream_send_recv) {
-    fossil_nstream_t *ns = fossil_nstream_open("tcp", "127.0.0.1", "8080", NULL);
-    ASSUME_NOT_CNULL(ns);
+FOSSIL_TEST_CASE(cpp_test_nstream_connect_invalid_host) {
+    fossil_nstream_t *stream = fossil_nstream_create("tcp", "client");
+    ASSUME_NOT_CNULL(stream);
 
-    const char *message = "Hello, Fossil!";
-    ssize_t bytes_sent = fossil_nstream_send(ns, message, strlen(message));
-    ASSUME_ITS_EQUAL_I32((int)strlen(message), bytes_sent);
-
-    char buffer[128];
-    ssize_t bytes_received = fossil_nstream_recv(ns, buffer, sizeof(buffer));
-    ASSUME_ITS_TRUE(bytes_received > 0);
-
-    fossil_nstream_close(ns);
+    // Attempt to connect to an invalid host
+    ASSUME_ITS_EQUAL_I32(-1, fossil_nstream_connect(stream, "invalid_host", 12345));
+    fossil_nstream_destroy(stream);
 }
 
-FOSSIL_TEST_CASE(cpp_test_nstream_listen_accept) {
-    fossil_nstream_t *server = fossil_nstream_open("tcp", "127.0.0.1", "8080", NULL);
+FOSSIL_TEST_CASE(cpp_test_nstream_listen_and_accept) {
+    fossil_nstream_t *server = fossil_nstream_create("tcp", "server");
     ASSUME_NOT_CNULL(server);
 
-    int result = fossil_nstream_listen(server, 5);
-    ASSUME_ITS_EQUAL_I32(0, result);
+    // Start listening on a local port
+    ASSUME_ITS_EQUAL_I32(0, fossil_nstream_listen(server, "127.0.0.1", 12345));
 
-    fossil_nstream_t *client = fossil_nstream_accept(server);
+    // Simulate a client connecting
+    fossil_nstream_t *client = fossil_nstream_create("tcp", "client");
     ASSUME_NOT_CNULL(client);
+    ASSUME_ITS_EQUAL_I32(0, fossil_nstream_connect(client, "127.0.0.1", 12345));
 
-    fossil_nstream_close(client);
-    fossil_nstream_close(server);
+    // Accept the client connection
+    fossil_nstream_t *accepted_client = fossil_nstream_accept(server);
+    ASSUME_NOT_CNULL(accepted_client);
+
+    // Cleanup
+    fossil_nstream_destroy(client);
+    fossil_nstream_destroy(accepted_client);
+    fossil_nstream_destroy(server);
 }
 
-FOSSIL_TEST_CASE(cpp_test_nstream_set_nonblocking) {
-    fossil_nstream_t *ns = fossil_nstream_open("tcp", "127.0.0.1", "8080", NULL);
-    ASSUME_NOT_CNULL(ns);
+FOSSIL_TEST_CASE(cpp_test_nstream_send_and_receive) {
+    fossil_nstream_t *server = fossil_nstream_create("tcp", "server");
+    ASSUME_NOT_CNULL(server);
 
-    int result = fossil_nstream_set_nonblocking(ns, 1);
-    ASSUME_ITS_EQUAL_I32(0, result);
+    // Start listening on a local port
+    ASSUME_ITS_EQUAL_I32(0, fossil_nstream_listen(server, "127.0.0.1", 12345));
 
-    fossil_nstream_close(ns);
+    // Simulate a client connecting
+    fossil_nstream_t *client = fossil_nstream_create("tcp", "client");
+    ASSUME_NOT_CNULL(client);
+    ASSUME_ITS_EQUAL_I32(0, fossil_nstream_connect(client, "127.0.0.1", 12345));
+
+    // Accept the client connection
+    fossil_nstream_t *accepted_client = fossil_nstream_accept(server);
+    ASSUME_NOT_CNULL(accepted_client);
+
+    // Send and receive data
+    const char *message = "Hello, Fossil!";
+    ASSUME_ITS_EQUAL_I32(strlen(message), fossil_nstream_send(client, message, strlen(message)));
+
+    char buffer[1024] = {0};
+    ASSUME_ITS_EQUAL_I32(strlen(message), fossil_nstream_recv(accepted_client, buffer, sizeof(buffer)));
+    ASSUME_ITS_EQUAL_CSTR(message, buffer);
+
+    // Cleanup
+    fossil_nstream_destroy(client);
+    fossil_nstream_destroy(accepted_client);
+    fossil_nstream_destroy(server);
 }
 
-FOSSIL_TEST_CASE(cpp_test_nstream_wait_readable_writable) {
-    fossil_nstream_t *ns = fossil_nstream_open("tcp", "127.0.0.1", "8080", NULL);
-    ASSUME_NOT_CNULL(ns);
+FOSSIL_TEST_CASE(cpp_test_nstream_protocols) {
+    const char *protocols[] = {"tcp", "udp", "raw", "icmp", "sctp", "http", "https", "ftp", "ssh", "dns", "ntp", "smtp", "pop3", "imap", "ldap", "mqtt"};
 
-    int result = fossil_nstream_wait_readable(ns, 1000);
-    ASSUME_ITS_TRUE(result == 0 || result == 1);
-
-    result = fossil_nstream_wait_writable(ns, 1000);
-    ASSUME_ITS_TRUE(result == 0 || result == 1);
-
-    fossil_nstream_close(ns);
+    for (size_t i = 0; i < sizeof(protocols) / sizeof(protocols[0]); i++) {
+        fossil_nstream_t *stream = fossil_nstream_create(protocols[i], "client");
+        ASSUME_NOT_CNULL(stream);
+        fossil_nstream_destroy(stream);
+    }
 }
 
-FOSSIL_TEST_CASE(cpp_test_nstream_connect_timeout) {
-    fossil_nstream_t *ns = fossil_nstream_open("tcp", NULL, NULL, NULL);
-    ASSUME_NOT_CNULL(ns);
+FOSSIL_TEST_CASE(cpp_test_nstream_client_types) {
+    const char *clients[] = {"mail-server", "server", "mail-client", "client", "mail-bot", "bot", "multicast", "broadcast"};
 
-    int result = fossil_nstream_connect_timeout(ns, "127.0.0.1", "8080", 1000);
-    ASSUME_ITS_EQUAL_I32(0, result);
-
-    fossil_nstream_close(ns);
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_get_peer_info) {
-    fossil_nstream_t *ns = fossil_nstream_open("tcp", "127.0.0.1", "8080", NULL);
-    ASSUME_NOT_CNULL(ns);
-
-    char ip_str[64];
-    uint16_t port;
-    int result = fossil_nstream_get_peer_info(ns, ip_str, sizeof(ip_str), &port);
-    ASSUME_ITS_EQUAL_I32(0, result);
-
-    fossil_nstream_close(ns);
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_send_recv_line) {
-    fossil_nstream_t *ns = fossil_nstream_open("tcp", "127.0.0.1", "8080", NULL);
-    ASSUME_NOT_CNULL(ns);
-
-    const char *line = "Hello, Fossil Logic!\n";
-    ssize_t bytes_sent = fossil_nstream_send_line(ns, line);
-    ASSUME_ITS_EQUAL_I32((int)strlen(line), bytes_sent);
-
-    char buffer[128];
-    ssize_t bytes_received = fossil_nstream_recv_line(ns, buffer, sizeof(buffer));
-    ASSUME_ITS_TRUE(bytes_received > 0);
-
-    fossil_nstream_close(ns);
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_ssl_send_recv) {
-    fossil_nstream_t *ns = fossil_nstream_open("tls", "127.0.0.1", "8080", NULL);
-    ASSUME_NOT_CNULL(ns);
-
-    const char *message = "Secure Hello!";
-    ssize_t bytes_sent = fossil_nstream_ssl_send(ns, message, strlen(message));
-    ASSUME_ITS_EQUAL_I32((int)strlen(message), bytes_sent);
-
-    char buffer[128];
-    ssize_t bytes_received = fossil_nstream_ssl_recv(ns, buffer, sizeof(buffer));
-    ASSUME_ITS_TRUE(bytes_received > 0);
-
-    fossil_nstream_close(ns);
-}
-
-/**
- * Test cases for the C++ NStream wrapper class.
- */
-
-FOSSIL_TEST_CASE(cpp_test_nstream_class_send_recv) {
-    fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-
-    const std::string message = "Hello, Fossil!";
-    ssize_t bytes_sent = ns.send(message.c_str(), message.size());
-    ASSUME_ITS_EQUAL_I32((int)message.size(), bytes_sent);
-
-    std::string buffer;
-    buffer.resize(128);
-    ssize_t bytes_received = ns.recv(&buffer[0], buffer.size());
-    ASSUME_ITS_TRUE(bytes_received > 0);
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_class_listen_accept) {
-    fossil::io::NStream server("tcp", "127.0.0.1", "8080", "");
-
-    int result = server.listen(5);
-    ASSUME_ITS_EQUAL_I32(0, result);
-
-    fossil::io::NStream *client = server.accept();
-
-    delete client;
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_class_set_nonblocking) {
-    fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-
-    int result = ns.set_non_blocking(1);
-    ASSUME_ITS_EQUAL_I32(0, result);
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_class_wait_readable_writable) {
-    fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-
-    int result = ns.wait_readable(1000);
-    ASSUME_ITS_TRUE(result == 0 || result == 1);
-
-    result = ns.wait_writable(1000);
-    ASSUME_ITS_TRUE(result == 0 || result == 1);
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_class_connect_timeout) {
-    fossil::io::NStream ns("tcp", "", "", "");
-
-    int result = ns.connect_timeout("127.0.0.1", "8080", 1000);
-    ASSUME_ITS_EQUAL_I32(0, result);
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_class_get_peer_info) {
-    fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-
-    std::string ip_str;
-    uint16_t port;
-    int result = ns.get_peer_info(ip_str, port);
-    ASSUME_ITS_EQUAL_I32(0, result);
-}
-
-FOSSIL_TEST_CASE(cpp_test_nstream_class_send_recv_line) {
-    fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-
-    const std::string line = "Hello, Fossil Logic!\n";
-    ssize_t bytes_sent = ns.send_line(line);
-    ASSUME_ITS_EQUAL_I32((int)line.size(), bytes_sent);
-
-    std::string buffer;
-    ssize_t bytes_received = ns.recv_line(buffer, 128);
-    ASSUME_ITS_TRUE(bytes_received > 0);
+    for (size_t i = 0; i < sizeof(clients) / sizeof(clients[0]); i++) {
+        fossil_nstream_t *stream = fossil_nstream_create("tcp", clients[i]);
+        ASSUME_NOT_CNULL(stream);
+        fossil_nstream_destroy(stream);
+    }
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
@@ -231,23 +136,12 @@ FOSSIL_TEST_CASE(cpp_test_nstream_class_send_recv_line) {
 // * * * * * * * * * * * * * * * * * * * * * * * *
 
 FOSSIL_TEST_GROUP(cpp_network_tests) {
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_open);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_send_recv);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_listen_accept);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_set_nonblocking);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_wait_readable_writable);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_connect_timeout);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_get_peer_info);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_send_recv_line);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_ssl_send_recv);
-
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_send_recv);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_listen_accept);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_set_nonblocking);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_wait_readable_writable);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_connect_timeout);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_get_peer_info);
-    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_send_recv_line);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_create_and_destroy);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_connect_invalid_host);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_listen_and_accept);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_send_and_receive);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_protocols);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_client_types);
 
     FOSSIL_TEST_REGISTER(cpp_network_suite);
 }

--- a/code/tests/cases/test_network.cpp
+++ b/code/tests/cases/test_network.cpp
@@ -156,14 +156,9 @@ FOSSIL_TEST_CASE(cpp_test_nstream_ssl_send_recv) {
 /**
  * Test cases for the C++ NStream wrapper class.
  */
-FOSSIL_TEST_CASE(cpp_test_nstream_class_open) {
-    fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-    ASSUME_NOT_CNULL(ns);
-}
 
 FOSSIL_TEST_CASE(cpp_test_nstream_class_send_recv) {
     fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-    ASSUME_NOT_CNULL(ns);
 
     const std::string message = "Hello, Fossil!";
     ssize_t bytes_sent = ns.send(message.c_str(), message.size());
@@ -177,20 +172,17 @@ FOSSIL_TEST_CASE(cpp_test_nstream_class_send_recv) {
 
 FOSSIL_TEST_CASE(cpp_test_nstream_class_listen_accept) {
     fossil::io::NStream server("tcp", "127.0.0.1", "8080", "");
-    ASSUME_NOT_CNULL(server);
 
     int result = server.listen(5);
     ASSUME_ITS_EQUAL_I32(0, result);
 
     fossil::io::NStream *client = server.accept();
-    ASSUME_NOT_CNULL(client);
 
     delete client;
 }
 
 FOSSIL_TEST_CASE(cpp_test_nstream_class_set_nonblocking) {
     fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-    ASSUME_NOT_CNULL(ns);
 
     int result = ns.set_non_blocking(1);
     ASSUME_ITS_EQUAL_I32(0, result);
@@ -198,7 +190,6 @@ FOSSIL_TEST_CASE(cpp_test_nstream_class_set_nonblocking) {
 
 FOSSIL_TEST_CASE(cpp_test_nstream_class_wait_readable_writable) {
     fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-    ASSUME_NOT_CNULL(ns);
 
     int result = ns.wait_readable(1000);
     ASSUME_ITS_TRUE(result == 0 || result == 1);
@@ -209,7 +200,6 @@ FOSSIL_TEST_CASE(cpp_test_nstream_class_wait_readable_writable) {
 
 FOSSIL_TEST_CASE(cpp_test_nstream_class_connect_timeout) {
     fossil::io::NStream ns("tcp", "", "", "");
-    ASSUME_NOT_CNULL(ns);
 
     int result = ns.connect_timeout("127.0.0.1", "8080", 1000);
     ASSUME_ITS_EQUAL_I32(0, result);
@@ -217,7 +207,6 @@ FOSSIL_TEST_CASE(cpp_test_nstream_class_connect_timeout) {
 
 FOSSIL_TEST_CASE(cpp_test_nstream_class_get_peer_info) {
     fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-    ASSUME_NOT_CNULL(ns);
 
     std::string ip_str;
     uint16_t port;
@@ -227,7 +216,6 @@ FOSSIL_TEST_CASE(cpp_test_nstream_class_get_peer_info) {
 
 FOSSIL_TEST_CASE(cpp_test_nstream_class_send_recv_line) {
     fossil::io::NStream ns("tcp", "127.0.0.1", "8080", "");
-    ASSUME_NOT_CNULL(ns);
 
     const std::string line = "Hello, Fossil Logic!\n";
     ssize_t bytes_sent = ns.send_line(line);
@@ -252,6 +240,15 @@ FOSSIL_TEST_GROUP(cpp_network_tests) {
     FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_get_peer_info);
     FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_send_recv_line);
     FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_ssl_send_recv);
+
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_send_recv);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_listen_accept);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_set_nonblocking);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_wait_readable_writable);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_connect_timeout);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_get_peer_info);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_send_recv_line);
+    FOSSIL_TEST_ADD(cpp_network_suite, cpp_test_nstream_class_ssl_send_recv);
 
     FOSSIL_TEST_REGISTER(cpp_network_suite);
 }


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description
Replaced old networking API with the new NStream API providing more control to the developer allowing them to create bots, mail services, and servers, along with a rich set of protocols.

## Testing
New test cases testing new NStream API and NStream class

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
