### PR TITLE
Enforce fstream handle

### DIFF
--- a/code/logic/fossil/io/input.h
+++ b/code/logic/fossil/io/input.h
@@ -362,7 +362,7 @@ namespace fossil {
              * @param input The Input object to populate.
              * @return The input stream after reading.
              */
-            friend std::istream &operator>>(std::istream &input_stream, Input &input) {
+            friend std::istream &operator>>(std::istream &input_stream, Input & /*input*/) {
                 // Implement the logic for populating the Input object from the input stream.
                 // This is a placeholder implementation.
                 char buffer[256];

--- a/code/logic/fossil/io/input.h
+++ b/code/logic/fossil/io/input.h
@@ -14,9 +14,8 @@
 #ifndef FOSSIL_IO_INPUT_H
 #define FOSSIL_IO_INPUT_H
 
-#include <stddef.h>
 #include <stdarg.h>
-#include <stdio.h>
+#include "stream.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,7 +27,7 @@ extern "C" {
  * @param input_stream  Pointer to the input stream to read from.
  * @return              The character read as an unsigned char cast to an int, or EOF on end-of-file or error.
  */
-int fossil_io_getc(FILE *input_stream);
+int fossil_io_getc(fossil_fstream_t *input_stream);
 
 /**
  * Reads a line from the input stream and stores it into the buffer pointed to by 'buf'.
@@ -38,7 +37,7 @@ int fossil_io_getc(FILE *input_stream);
  * @param input_stream  Pointer to the input stream to read from.
  * @return              On success, the function returns 'buf'. If the end-of-file is reached or an error occurs, it returns NULL.
  */
-char *fossil_io_gets_from_stream(char *buf, size_t size, FILE *input_stream);
+char *fossil_io_gets_from_stream(char *buf, size_t size, fossil_fstream_t *input_stream);
 
 /**
  * Reads a line from the input stream with error reporting.
@@ -49,7 +48,7 @@ char *fossil_io_gets_from_stream(char *buf, size_t size, FILE *input_stream);
  * @param error_code    Pointer to an integer to store the error code (e.g., EOF, input error).
  * @return              On success, the function returns 'buf'. If the end-of-file is reached or an error occurs, it returns NULL.
  */
-char *fossil_io_gets_from_stream_ex(char *buf, size_t size, FILE *input_stream, int *error_code);
+char *fossil_io_gets_from_stream_ex(char *buf, size_t size, fossil_fstream_t *input_stream, int *error_code);
 
 /**
  * Reads formatted input from the standard input stream.
@@ -70,7 +69,7 @@ int fossil_io_scanf(const char *format, ...);
  * @return              On success, the number of input items successfully matched and assigned is returned.
  *                      On failure, EOF is returned.
  */
-int fossil_io_fscanf(FILE *input_stream, const char *format, ...);
+int fossil_io_fscanf(fossil_fstream_t *input_stream, const char *format, ...);
 
 /**
  * Validates the input buffer and size before reading.
@@ -89,7 +88,7 @@ int fossil_io_validate_input_buffer(const char *buf, size_t size);
  * @param input_stream  Pointer to the input stream to read from.
  * @return              On success, the function returns 'buf'. If the end-of-file is reached or an error occurs, it returns NULL.
  */
-char *fossil_io_gets_utf8(char *buf, size_t size, FILE *input_stream);
+char *fossil_io_gets_utf8(char *buf, size_t size, fossil_fstream_t *input_stream);
 
 /**
  * @brief Validates if the input string is a valid integer.
@@ -185,7 +184,7 @@ namespace fossil {
              * @param input_stream  Pointer to the input stream to read from.
              * @return              The character read as an unsigned char cast to an int, or EOF on end-of-file or error.
              */
-            static int getc(FILE *input_stream) {
+            static int getc(fossil_fstream_t *input_stream) {
                 return fossil_io_getc(input_stream);
             }
 
@@ -197,7 +196,7 @@ namespace fossil {
              * @param input_stream  Pointer to the input stream to read from.
              * @return              On success, the function returns 'buf'. If the end-of-file is reached or an error occurs, it returns NULL.
              */
-            static char *gets_from_stream(char *buf, size_t size, FILE *input_stream) {
+            static char *gets_from_stream(char *buf, size_t size, fossil_fstream_t *input_stream) {
                 return fossil_io_gets_from_stream(buf, size, input_stream);
             }
 
@@ -210,7 +209,7 @@ namespace fossil {
              * @param error_code    Pointer to an integer to store the error code (e.g., EOF, input error).
              * @return              On success, the function returns 'buf'. If the end-of-file is reached or an error occurs, it returns NULL.
              */
-            static char *gets_from_stream_ex(char *buf, size_t size, FILE *input_stream, int *error_code) {
+            static char *gets_from_stream_ex(char *buf, size_t size, fossil_fstream_t *input_stream, int *error_code) {
                 return fossil_io_gets_from_stream_ex(buf, size, input_stream, error_code);
             }
 
@@ -233,7 +232,7 @@ namespace fossil {
              * @param input_stream  Pointer to the input stream to read from.
              * @return              On success, the function returns 'buf'. If the end-of-file is reached or an error occurs, it returns NULL.
              */
-            static char *gets_utf8(char *buf, size_t size, FILE *input_stream) {
+            static char *gets_utf8(char *buf, size_t size, fossil_fstream_t *input_stream) {
                 return fossil_io_gets_utf8(buf, size, input_stream);
             }
 
@@ -262,7 +261,7 @@ namespace fossil {
              * @return              On success, the number of input items successfully matched and assigned is returned.
              *                      On failure, EOF is returned.
              */
-            static int fscanf(FILE *input_stream, const char *format, ...) {
+            static int fscanf(fossil_fstream_t *input_stream, const char *format, ...) {
                 va_list args;
                 va_start(args, format);
                 int result = fossil_io_fscanf(input_stream, format, args);
@@ -357,25 +356,21 @@ namespace fossil {
             }
 
             /**
-             * @brief Override the output stream operator to display Input object details.
+             * @brief Overloads the input stream operator for the Input class.
              * 
-             * @param os The output stream where data will be printed.
-             * @param input The Input object to display.
-             * @return The modified output stream.
+             * @param input_stream The input stream to read from.
+             * @param input The Input object to populate.
+             * @return The input stream after reading.
              */
-            friend std::ostream& operator<<(std::ostream& os, const Input& input) {
-                // Example of what to output: printing the state or some meaningful data
-                os << "Input Stream Details:\n";
-                os << " - Max Buffer Size: " << input.max_buffer_size << "\n";
-                os << " - Input Stream: " << (input.stream ? "Valid Stream" : "Invalid Stream") << "\n";
-                
-                // Return the output stream
-                return os;
+            friend std::istream &operator>>(std::istream &input_stream, Input &input) {
+                // Implement the logic for populating the Input object from the input stream.
+                // This is a placeholder implementation.
+                char buffer[256];
+                input_stream.getline(buffer, sizeof(buffer));
+                // Process the buffer as needed to populate the Input object.
+                return input_stream;
             }
 
-        private:
-            size_t max_buffer_size;  // Example private member
-            FILE* stream;            // Example stream (pointer to the input stream, like stdin)
         };
 
     }

--- a/code/tests/cases/test_input.c
+++ b/code/tests/cases/test_input.c
@@ -45,15 +45,15 @@ FOSSIL_TEARDOWN(c_input_suite) {
 
 FOSSIL_TEST_CASE(c_test_io_gets_from_stream) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream = {tmpfile(), "tempfile"};
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(c_test_io_gets_from_stream_no_offensive) {
@@ -61,11 +61,11 @@ FOSSIL_TEST_CASE(c_test_io_gets_from_stream_no_offensive) {
     char expected[] = "This is a clean sentence.";
     char buffer[256];
 
-    FILE *stream = tmpfile();
-    fwrite(input, 1, strlen(input), stream);
-    rewind(stream);
-    char *result = fossil_io_gets_from_stream(buffer, sizeof(buffer), stream);
-    fclose(stream);
+    fossil_fstream_t stream = {tmpfile(), "tempfile"};
+    fwrite(input, 1, strlen(input), stream.file);
+    rewind(stream.file);
+    char *result = fossil_io_gets_from_stream(buffer, sizeof(buffer), &stream);
+    fclose(stream.file);
 
     ASSUME_ITS_EQUAL_CSTR(expected, result);
 }
@@ -75,79 +75,79 @@ FOSSIL_TEST_CASE(c_test_io_gets_from_stream_with_punctuation) {
     char expected[] = "This is a test with punctuation, and special characters!";
     char buffer[256];
 
-    FILE *stream = tmpfile();
-    fwrite(input, 1, strlen(input), stream);
-    rewind(stream);
-    char *result = fossil_io_gets_from_stream(buffer, sizeof(buffer), stream);
-    fclose(stream);
+    fossil_fstream_t stream = {tmpfile(), "tempfile"};
+    fwrite(input, 1, strlen(input), stream.file);
+    rewind(stream.file);
+    char *result = fossil_io_gets_from_stream(buffer, sizeof(buffer), &stream);
+    fclose(stream.file);
 
     ASSUME_ITS_EQUAL_CSTR(expected, result);
 }
 
 FOSSIL_TEST_CASE(c_test_io_gets_from_stream_empty_input) {
     const char *input_data = "\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream = {tmpfile(), "tempfile"};
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(c_test_io_gets_from_stream_only_whitespace) {
     const char *input_data = "   \n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream = {tmpfile(), "tempfile"};
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(c_test_io_gets_from_stream_long_input) {
     const char *input_data = "This is a very long input string that exceeds the buffer size\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream = {tmpfile(), "tempfile"};
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("This is a very long", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(c_test_io_gets_from_stream_ex) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream = {tmpfile(), "tempfile"};
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
     int error_code = 0;
-    char *result = fossil_io_gets_from_stream_ex(buf, sizeof(buf), input_stream, &error_code);
+    char *result = fossil_io_gets_from_stream_ex(buf, sizeof(buf), &input_stream, &error_code);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(c_test_io_gets_utf8) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream = {tmpfile(), "tempfile"};
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_utf8(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_utf8(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(c_test_io_validate_is_int_valid) {
@@ -185,7 +185,7 @@ FOSSIL_TEST_CASE(c_test_io_validate_is_alnum_invalid) {
 }
 
 FOSSIL_TEST_CASE(c_test_io_validate_is_email_valid) {
-    const char *input = "test@example.com";
+    const char *input = "test@gmail.com"; // now checks for valid email providers like gmail.com
     int result = fossil_io_validate_is_email(input);
     ASSUME_ITS_TRUE(result);
 }
@@ -210,13 +210,13 @@ FOSSIL_TEST_CASE(c_test_io_validate_is_length_invalid) {
 
 FOSSIL_TEST_CASE(c_test_io_getc) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream = {tmpfile(), "tempfile"};
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
-    int ch = fossil_io_getc(input_stream);
+    int ch = fossil_io_getc(&input_stream);
     ASSUME_ITS_EQUAL_I32('t', ch);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *

--- a/code/tests/cases/test_input.cpp
+++ b/code/tests/cases/test_input.cpp
@@ -45,15 +45,18 @@ FOSSIL_TEARDOWN(cpp_input_suite) {
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "test_input_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_no_offensive) {
@@ -61,11 +64,14 @@ FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_no_offensive) {
     char expected[] = "This is a clean sentence.";
     char buffer[256];
 
-    FILE *stream = tmpfile();
-    fwrite(input, 1, strlen(input), stream);
-    rewind(stream);
-    char *result = fossil_io_gets_from_stream(buffer, sizeof(buffer), stream);
-    fclose(stream);
+    fossil_fstream_t stream;
+    stream.file = tmpfile();
+    strcpy(stream.filename, "clean_sentence_stream");
+
+    fwrite(input, 1, strlen(input), stream.file);
+    rewind(stream.file);
+    char *result = fossil_io_gets_from_stream(buffer, sizeof(buffer), &stream);
+    fclose(stream.file);
 
     ASSUME_ITS_EQUAL_CSTR(expected, result);
 }
@@ -75,106 +81,130 @@ FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_with_punctuation) {
     char expected[] = "This is a test with punctuation, and special characters!";
     char buffer[256];
 
-    FILE *stream = tmpfile();
-    fwrite(input, 1, strlen(input), stream);
-    rewind(stream);
-    char *result = fossil_io_gets_from_stream(buffer, sizeof(buffer), stream);
-    fclose(stream);
+    fossil_fstream_t stream;
+    stream.file = tmpfile();
+    strcpy(stream.filename, "punctuation_stream");
+
+    fwrite(input, 1, strlen(input), stream.file);
+    rewind(stream.file);
+    char *result = fossil_io_gets_from_stream(buffer, sizeof(buffer), &stream);
+    fclose(stream.file);
 
     ASSUME_ITS_EQUAL_CSTR(expected, result);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_empty_input) {
     const char *input_data = "\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "empty_input_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_only_whitespace) {
     const char *input_data = "   \n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "whitespace_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_long_input) {
     const char *input_data = "This is a very long input string that exceeds the buffer size\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "long_input_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("This is a very long", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_ex) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "stream_ex");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
     int error_code = 0;
-    char *result = fossil_io_gets_from_stream_ex(buf, sizeof(buf), input_stream, &error_code);
+    char *result = fossil_io_gets_from_stream_ex(buf, sizeof(buf), &input_stream, &error_code);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_utf8) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "utf8_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil_io_gets_utf8(buf, sizeof(buf), input_stream);
+    char *result = fossil_io_gets_utf8(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_class) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "class_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil::io::Input::gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil::io::Input::gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_from_stream_ex_class) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "class_stream_ex");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
     int error_code = 0;
-    char *result = fossil::io::Input::gets_from_stream_ex(buf, sizeof(buf), input_stream, &error_code);
+    char *result = fossil::io::Input::gets_from_stream_ex(buf, sizeof(buf), &input_stream, &error_code);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_validate_input_buffer_class) {
@@ -186,15 +216,18 @@ FOSSIL_TEST_CASE(cpp_test_io_validate_input_buffer_class) {
 
 FOSSIL_TEST_CASE(cpp_test_io_gets_utf8_class) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "utf8_class_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil::io::Input::gets_utf8(buf, sizeof(buf), input_stream);
+    char *result = fossil::io::Input::gets_utf8(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("test input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_validate_is_int_valid) {
@@ -232,7 +265,7 @@ FOSSIL_TEST_CASE(cpp_test_io_validate_is_alnum_invalid) {
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_validate_is_email_valid) {
-    const char *input = "test@example.com";
+    const char *input = "test@icloud.com";
     int result = fossil_io_validate_is_email(input);
     ASSUME_ITS_TRUE(result);
 }
@@ -257,29 +290,35 @@ FOSSIL_TEST_CASE(cpp_test_io_validate_is_length_invalid) {
 
 FOSSIL_TEST_CASE(cpp_test_io_input_class_gets_from_stream) {
     const char *input_data = "input data\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "input_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil::io::Input::gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil::io::Input::gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("input data", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_input_class_gets_from_stream_ex) {
     const char *input_data = "input data\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "input_stream_ex");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
     int error_code = 0;
-    char *result = fossil::io::Input::gets_from_stream_ex(buf, sizeof(buf), input_stream, &error_code);
+    char *result = fossil::io::Input::gets_from_stream_ex(buf, sizeof(buf), &input_stream, &error_code);
     ASSUME_ITS_EQUAL_CSTR("input data", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_input_class_validate_input_buffer_valid) {
@@ -298,52 +337,64 @@ FOSSIL_TEST_CASE(cpp_test_io_input_class_validate_input_buffer_invalid) {
 
 FOSSIL_TEST_CASE(cpp_test_io_input_class_gets_utf8_valid) {
     const char *input_data = "utf8 valid input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "utf8_valid_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil::io::Input::gets_utf8(buf, sizeof(buf), input_stream);
+    char *result = fossil::io::Input::gets_utf8(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("utf8 valid input", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_input_class_gets_from_stream_empty) {
     const char *input_data = "\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "empty_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil::io::Input::gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil::io::Input::gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_input_class_gets_from_stream_whitespace_only) {
     const char *input_data = "   \n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "whitespace_stream");
+
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
 
     char buf[20];
-    char *result = fossil::io::Input::gets_from_stream(buf, sizeof(buf), input_stream);
+    char *result = fossil::io::Input::gets_from_stream(buf, sizeof(buf), &input_stream);
     ASSUME_ITS_EQUAL_CSTR("", buf);
     ASSUME_NOT_CNULL(result);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 FOSSIL_TEST_CASE(cpp_test_io_getc) {
     const char *input_data = "test input\n";
-    FILE *input_stream = tmpfile();
-    fwrite(input_data, 1, strlen(input_data), input_stream);
-    rewind(input_stream);
+    fossil_fstream_t input_stream;
+    input_stream.file = tmpfile();
+    strcpy(input_stream.filename, "getc_stream");
 
-    int ch = fossil::io::Input::getc(input_stream);
+    fwrite(input_data, 1, strlen(input_data), input_stream.file);
+    rewind(input_stream.file);
+
+    int ch = fossil::io::Input::getc(&input_stream);
     ASSUME_ITS_EQUAL_I32('t', ch);
-    fclose(input_stream);
+    fclose(input_stream.file);
 }
 
 // * * * * * * * * * * * * * * * * * * * * * * * *


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description
Updating input functions to use the Fossil file stream handler. Additionally added new check point for valid email providers.

## Testing
Updated test cases to use Fossil file stream handler vs the classic file handler.

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
