### PR TITLE
Add flags for toggling coler and attr

### DIFF
--- a/code/logic/device.c
+++ b/code/logic/device.c
@@ -338,10 +338,8 @@ void fossil_io_touch_clear_bindings(void) {
 
 void fossil_io_touch_init(void) {
     memset(&touch_manager, 0, sizeof(touch_manager));
-    fossil_io_printf("[touch] Initialized: bindings cleared\n");
 }
 
 void fossil_io_touch_shutdown(void) {
     memset(&touch_manager, 0, sizeof(touch_manager));
-    fossil_io_printf("[touch] Shutdown: bindings released\n");
 }

--- a/code/logic/device.c
+++ b/code/logic/device.c
@@ -12,6 +12,7 @@
  * -----------------------------------------------------------------------------
  */
 #include "fossil/io/device.h"
+#include "fossil/io/output.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -139,7 +140,6 @@ static fossil_io_keyboard_event_t fossil_io_keyboard_get_event(void) {
 
 void fossil_io_keyboard_init(void) {
     memset(&keyboard_manager, 0, sizeof(keyboard_manager));
-    printf("[mouse] Initialized: bindings cleared\n");
 #if defined(_WIN32) || defined(_WIN64)
     // Windows doesn't require explicit setup for raw mode.
 #else
@@ -150,7 +150,6 @@ void fossil_io_keyboard_init(void) {
 
 void fossil_io_keyboard_shutdown(void) {
     memset(&keyboard_manager, 0, sizeof(keyboard_manager));
-    printf("[mouse] Shutdown: bindings released\n");
 #if defined(_WIN32) || defined(_WIN64)
     // Windows doesn't require explicit cleanup for raw mode.
 #else
@@ -168,7 +167,7 @@ void fossil_io_keyboard_register_binding(fossil_io_keyboard_event_t event, fossi
         keyboard_manager.bindings[keyboard_manager.count].callback = callback;
         keyboard_manager.count++;
     } else {
-        fprintf(stderr, "Max keybindings reached.\n");
+        fossil_io_fprintf(FOSSIL_STDERR, "Max keybindings reached.\n");
     }
 }
 
@@ -185,7 +184,7 @@ void fossil_io_keyboard_unregister_binding(fossil_io_keyboard_event_t event) {
             return;
         }
     }
-    fprintf(stderr, "No matching keybinding to unregister.\n");
+    fossil_io_fprintf(FOSSIL_STDERR, "No matching keybinding to unregister.\n");
 }
 
 void fossil_io_keyboard_poll_events(void) {
@@ -228,7 +227,7 @@ static void fossil_io_mouse_get_event(fossil_io_mouse_event_t* event) {
 
 void fossil_io_mouse_register_binding(fossil_io_mouse_event_t event, fossil_io_mouse_callback_t callback) {
     if (mouse_manager.count >= MAX_MOUSEBINDS) {
-        fprintf(stderr, "[mouse] Max bindings reached\n");
+        fossil_io_fprintf(FOSSIL_STDERR, "[mouse] Max bindings reached\n");
         return;
     }
 
@@ -244,7 +243,7 @@ void fossil_io_mouse_unregister_binding(fossil_io_mouse_event_t event) {
             return;
         }
     }
-    fprintf(stderr, "[mouse] Binding not found\n");
+    fossil_io_fprintf(FOSSIL_STDERR, "[mouse] Binding not found\n");
 }
 
 void fossil_io_mouse_poll_events(void) {
@@ -269,12 +268,10 @@ void fossil_io_mouse_clear_bindings(void) {
 
 void fossil_io_mouse_init(void) {
     memset(&mouse_manager, 0, sizeof(mouse_manager));
-    printf("[mouse] Initialized: bindings cleared\n");
 }
 
 void fossil_io_mouse_shutdown(void) {
     memset(&mouse_manager, 0, sizeof(mouse_manager));
-    printf("[mouse] Shutdown: bindings released\n");
 }
 
 // TOUCH
@@ -300,7 +297,7 @@ static void fossil_io_touch_get_event(fossil_io_touch_event_t* event) {
 
 void fossil_io_touch_register_binding(fossil_io_touch_event_t event, fossil_io_touch_callback_t callback) {
     if (touch_manager.count >= MAX_TOUCHBINDS) {
-        fprintf(stderr, "[touch] Max bindings reached\n");
+        fossil_io_fprintf(FOSSIL_STDERR, "[touch] Max bindings reached\n");
         return;
     }
 
@@ -316,7 +313,7 @@ void fossil_io_touch_unregister_binding(fossil_io_touch_event_t event) {
             return;
         }
     }
-    fprintf(stderr, "[touch] Binding not found\n");
+    fossil_io_fprintf(FOSSIL_STDERR, "[touch] Binding not found\n");
 }
 
 void fossil_io_touch_poll_events(void) {
@@ -341,10 +338,10 @@ void fossil_io_touch_clear_bindings(void) {
 
 void fossil_io_touch_init(void) {
     memset(&touch_manager, 0, sizeof(touch_manager));
-    printf("[touch] Initialized: bindings cleared\n");
+    fossil_io_printf("[touch] Initialized: bindings cleared\n");
 }
 
 void fossil_io_touch_shutdown(void) {
     memset(&touch_manager, 0, sizeof(touch_manager));
-    printf("[touch] Shutdown: bindings released\n");
+    fossil_io_printf("[touch] Shutdown: bindings released\n");
 }

--- a/code/logic/fossil/io/output.h
+++ b/code/logic/fossil/io/output.h
@@ -21,6 +21,9 @@
 extern "C" {
 #endif
 
+extern int32_t FOSSIL_IO_COLOR_ENABLE; // Flag to enable/disable color output
+extern int32_t FOSSIL_IO_ATTR_ENABLE; // Flag to enable/disable attribute output
+
 /** 
  * This code provides a robust set of functions for formatting and manipulating terminal output, 
  * allowing developers to apply color, text attributes (like bold, underline, etc.), and cursor positioning 
@@ -69,6 +72,16 @@ extern "C" {
  * command-line interfaces. The markup-based approach is simple to use and can be easily extended to meet the 
  * needs of more complex applications.
  */
+
+/**
+ * Redirects the output to a specified stream.
+ *
+ * This function allows you to change the default output destination to a custom stream.
+ * It is useful when you want to redirect output to a file or another output stream.
+ *
+ * @param stream The output stream where subsequent output should be redirected.
+ */
+void fossil_io_redirect_output(fossil_fstream_t *stream);
 
 /**
  * Prints a string to the output.

--- a/code/logic/output.c
+++ b/code/logic/output.c
@@ -18,6 +18,9 @@
 #include <string.h>
 #include <stdio.h>
 
+int32_t FOSSIL_IO_COLOR_ENABLE = 1; // Flag to enable/disable color output
+int32_t FOSSIL_IO_ATTR_ENABLE = 1; // Flag to enable/disable attribute output
+
 // Define color codes for output
 #define FOSSIL_IO_COLOR_RESET       "\033[0m"
 #define FOSSIL_IO_COLOR_RED         "\033[31m"
@@ -171,11 +174,11 @@ void fossil_io_print_with_attributes(const char *format, ...) {
                 pos = color + 4; // Skip the "pos:" prefix
                 fossil_io_apply_position(pos);
             } else {
-                // Apply color and/or attribute
-                if (color) {
+                // Apply color and/or attribute based on flags
+                if (FOSSIL_IO_COLOR_ENABLE && color) {
                     fossil_io_apply_color(color);
                 }
-                if (attribute) {
+                if (FOSSIL_IO_ATTR_ENABLE && attribute) {
                     fossil_io_apply_attribute(attribute);
                 }
             }


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description
Toggle flags for color and attributes have been added to make it easy to enable or disable via a command-line argument if the developer chooses to override the flags and provide the user the options.

## Testing
<!-- Describe the testing process or steps taken to ensure the changes work as expected. -->

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
