### PR TITLE
Extend cstring api

### DIFF
--- a/code/logic/cstring.c
+++ b/code/logic/cstring.c
@@ -998,3 +998,119 @@ ccstring fossil_io_cstring_stream_read(fossil_io_cstring_stream *stream) {
     if (!stream) return NULL;
     return stream->buffer;
 }
+
+/* ---------------- Creation & Destruction ---------------- */
+fossil_io_cstring_stream* fossil_io_cstring_stream_create(size_t initial_size) {
+    fossil_io_cstring_stream *stream = (fossil_io_cstring_stream*)malloc(sizeof(fossil_io_cstring_stream));
+    if (!stream) return NULL;
+    stream->buffer = (char*)malloc(initial_size);
+    if (!stream->buffer) {
+        free(stream);
+        return NULL;
+    }
+    stream->buffer[0] = '\0';
+    stream->length = 0;
+    stream->capacity = initial_size;
+    return stream;
+}
+
+void fossil_io_cstring_stream_free(fossil_io_cstring_stream *stream) {
+    if (!stream) return;
+    free(stream->buffer);
+    free(stream);
+}
+
+/* ---------------- Internal Helper ---------------- */
+static int fossil_io_cstring_stream_ensure_capacity(fossil_io_cstring_stream *stream, size_t needed) {
+    if (!stream) return -1;
+    if (needed <= stream->capacity) return 0;
+    size_t new_capacity = stream->capacity * 2;
+    if (new_capacity < needed) new_capacity = needed;
+    char *new_buf = (char*)realloc(stream->buffer, new_capacity);
+    if (!new_buf) return -1;
+    stream->buffer = new_buf;
+    stream->capacity = new_capacity;
+    return 0;
+}
+
+/* ---------------- Basic Write ---------------- */
+void fossil_io_cstring_stream_write(fossil_io_cstring_stream *stream, ccstring str) {
+    if (!stream || !str) return;
+    size_t len = strlen(str);
+    if (fossil_io_cstring_stream_ensure_capacity(stream, stream->length + len + 1) != 0) return;
+    memcpy(stream->buffer + stream->length, str, len);
+    stream->length += len;
+    stream->buffer[stream->length] = '\0';
+}
+
+/* ---------------- Safe Write ---------------- */
+void fossil_io_cstring_stream_write_safe(fossil_io_cstring_stream *stream, ccstring str, size_t max_len) {
+    if (!stream || !str) return;
+    size_t len = strnlen(str, max_len);
+    if (fossil_io_cstring_stream_ensure_capacity(stream, stream->length + len + 1) != 0) return;
+    memcpy(stream->buffer + stream->length, str, len);
+    stream->length += len;
+    stream->buffer[stream->length] = '\0';
+}
+
+/* ---------------- Formatted Write ---------------- */
+void fossil_io_cstring_stream_write_format(fossil_io_cstring_stream *stream, ccstring format, ...) {
+    if (!stream || !format) return;
+    va_list args;
+    va_start(args, format);
+    int needed = vsnprintf(NULL, 0, format, args);
+    va_end(args);
+    if (needed <= 0) return;
+    if (fossil_io_cstring_stream_ensure_capacity(stream, stream->length + needed + 1) != 0) return;
+
+    va_start(args, format);
+    vsnprintf(stream->buffer + stream->length, needed + 1, format, args);
+    va_end(args);
+    stream->length += needed;
+}
+
+/* ---------------- Insert ---------------- */
+void fossil_io_cstring_stream_insert(fossil_io_cstring_stream *stream, ccstring str, size_t pos) {
+    if (!stream || !str || pos > stream->length) return;
+    size_t len = strlen(str);
+    if (fossil_io_cstring_stream_ensure_capacity(stream, stream->length + len + 1) != 0) return;
+    memmove(stream->buffer + pos + len, stream->buffer + pos, stream->length - pos + 1);
+    memcpy(stream->buffer + pos, str, len);
+    stream->length += len;
+}
+
+/* ---------------- Truncate ---------------- */
+void fossil_io_cstring_stream_truncate(fossil_io_cstring_stream *stream, size_t new_length) {
+    if (!stream) return;
+    if (new_length >= stream->length) return;
+    stream->length = new_length;
+    stream->buffer[new_length] = '\0';
+}
+
+/* ---------------- Clear ---------------- */
+void fossil_io_cstring_stream_clear(fossil_io_cstring_stream *stream) {
+    if (!stream) return;
+    stream->length = 0;
+    if (stream->buffer) stream->buffer[0] = '\0';
+}
+
+/* ---------------- Reserve ---------------- */
+int fossil_io_cstring_stream_reserve(fossil_io_cstring_stream *stream, size_t min_capacity) {
+    if (!stream) return -1;
+    return fossil_io_cstring_stream_ensure_capacity(stream, min_capacity);
+}
+
+/* ---------------- Read ---------------- */
+ccstring fossil_io_cstring_stream_read(fossil_io_cstring_stream *stream) {
+    if (!stream) return NULL;
+    return stream->buffer;
+}
+
+/* ---------------- Length / Remaining ---------------- */
+size_t fossil_io_cstring_stream_length(fossil_io_cstring_stream *stream) {
+    return stream ? stream->length : 0;
+}
+
+size_t fossil_io_cstring_stream_capacity_remaining(fossil_io_cstring_stream *stream) {
+    return stream ? (stream->capacity - stream->length) : 0;
+}

--- a/code/logic/fossil/io/cstring.h
+++ b/code/logic/fossil/io/cstring.h
@@ -745,6 +745,81 @@ void fossil_io_cstring_stream_write(fossil_io_cstring_stream *stream, ccstring s
  */
 ccstring fossil_io_cstring_stream_read(fossil_io_cstring_stream *stream);
 
+/**
+ * @brief Writes a string to the stream safely, respecting a maximum length.
+ *
+ * @param stream Pointer to the stream.
+ * @param str Null-terminated string to append.
+ * @param max_len Maximum number of characters to append.
+ */
+void fossil_io_cstring_stream_write_safe(fossil_io_cstring_stream *stream, ccstring str, size_t max_len);
+
+/**
+ * @brief Writes a formatted string to the stream (like printf).
+ *
+ * @param stream Pointer to the stream.
+ * @param format Format string.
+ * @param ... Format arguments.
+ */
+void fossil_io_cstring_stream_write_format(fossil_io_cstring_stream *stream, ccstring format, ...);
+
+/**
+ * @brief Inserts a cstring at a specified position in the stream.
+ *
+ * Shifts existing data to accommodate the new string.
+ *
+ * @param stream Pointer to the stream.
+ * @param str String to insert.
+ * @param pos Position to insert at (0 = beginning).
+ */
+void fossil_io_cstring_stream_insert(fossil_io_cstring_stream *stream, ccstring str, size_t pos);
+
+/**
+ * @brief Truncates the stream to the specified length.
+ *
+ * Reduces the stream length safely, optionally zeroing truncated data.
+ *
+ * @param stream Pointer to the stream.
+ * @param new_length New desired length of the stream.
+ */
+void fossil_io_cstring_stream_truncate(fossil_io_cstring_stream *stream, size_t new_length);
+
+/**
+ * @brief Clears the stream content without freeing the buffer.
+ *
+ * Resets length to 0 and optionally zeroes memory.
+ *
+ * @param stream Pointer to the stream.
+ */
+void fossil_io_cstring_stream_clear(fossil_io_cstring_stream *stream);
+
+/**
+ * @brief Ensures the stream has at least the specified capacity.
+ *
+ * Resizes the buffer if necessary.
+ *
+ * @param stream Pointer to the stream.
+ * @param min_capacity Minimum capacity required.
+ * @return 0 on success, non-zero on allocation failure.
+ */
+int fossil_io_cstring_stream_reserve(fossil_io_cstring_stream *stream, size_t min_capacity);
+
+/**
+ * @brief Returns the current length of the stream.
+ *
+ * @param stream Pointer to the stream.
+ * @return Length of data in the stream.
+ */
+size_t fossil_io_cstring_stream_length(fossil_io_cstring_stream *stream);
+
+/**
+ * @brief Returns the remaining capacity of the stream.
+ *
+ * @param stream Pointer to the stream.
+ * @return Number of bytes available before resizing is required.
+ */
+size_t fossil_io_cstring_stream_capacity_remaining(fossil_io_cstring_stream *stream);
+
 #ifdef __cplusplus
 }
 

--- a/code/logic/fossil/io/cstring.h
+++ b/code/logic/fossil/io/cstring.h
@@ -536,6 +536,182 @@ cstring fossil_io_cstring_escape_json_safe(ccstring str, size_t max_len);
  */
 cstring fossil_io_cstring_unescape_json_safe(ccstring str, size_t max_len);
 
+/**
+ * @brief Extracts a substring from a given cstring safely.
+ *
+ * Ensures bounds checking and respects maximum length.
+ *
+ * @param str The original cstring.
+ * @param start The starting index for the substring.
+ * @param length The number of characters to include.
+ * @param max_len Maximum allowed length to prevent buffer overrun.
+ * @return A newly allocated cstring containing the substring, or NULL on failure.
+ */
+cstring fossil_io_cstring_substring_safe(ccstring str, size_t start, size_t length, size_t max_len);
+
+/**
+ * @brief Reverses a cstring safely.
+ *
+ * Creates a new string that is the reverse of the input while ensuring memory safety.
+ *
+ * @param str The cstring to reverse.
+ * @param max_len Maximum length to process to prevent overflow.
+ * @return A newly allocated reversed cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_reverse_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Checks if a cstring contains a substring safely.
+ *
+ * Ensures that no buffer overruns occur.
+ *
+ * @param str The cstring to search.
+ * @param substr The substring to look for.
+ * @param max_len Maximum number of characters to scan.
+ * @return 1 if substring exists, 0 otherwise.
+ */
+int fossil_io_cstring_contains_safe(ccstring str, ccstring substr, size_t max_len);
+
+/**
+ * @brief Repeats a cstring multiple times safely.
+ *
+ * Ensures the resulting string does not exceed max_len.
+ *
+ * @param str The string to repeat.
+ * @param count Number of repetitions.
+ * @param max_len Maximum length of resulting string.
+ * @return A newly allocated repeated cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_repeat_safe(ccstring str, size_t count, size_t max_len);
+
+/**
+ * @brief Strips a specified character from both ends of a cstring safely.
+ *
+ * @param str The cstring to process.
+ * @param ch The character to strip.
+ * @param max_len Maximum length to process.
+ * @return A new cstring with the specified character removed from start and end.
+ */
+cstring fossil_io_cstring_strip_safe(ccstring str, char ch, size_t max_len);
+
+/**
+ * @brief Counts the occurrences of a substring within a cstring safely.
+ *
+ * Ensures safe bounds checking.
+ *
+ * @param str The cstring to search.
+ * @param substr The substring to count.
+ * @param max_len Maximum length to scan.
+ * @return The number of occurrences of the substring.
+ */
+size_t fossil_io_cstring_count_safe(ccstring str, ccstring substr, size_t max_len);
+
+/**
+ * @brief Pads a cstring on the left with a specific character safely.
+ *
+ * Ensures total length does not exceed max_len.
+ *
+ * @param str The cstring to pad.
+ * @param total_length The desired total length after padding.
+ * @param pad_char Character to pad with.
+ * @param max_len Maximum allowed length of the resulting string.
+ * @return A newly allocated padded cstring.
+ */
+cstring fossil_io_cstring_pad_left_safe(ccstring str, size_t total_length, char pad_char, size_t max_len);
+
+/**
+ * @brief Pads a cstring on the right with a specific character safely.
+ *
+ * Ensures total length does not exceed max_len.
+ *
+ * @param str The cstring to pad.
+ * @param total_length The desired total length after padding.
+ * @param pad_char Character to pad with.
+ * @param max_len Maximum allowed length of the resulting string.
+ * @return A newly allocated padded cstring.
+ */
+cstring fossil_io_cstring_pad_right_safe(ccstring str, size_t total_length, char pad_char, size_t max_len);
+
+/**
+ * @brief Checks if a cstring starts with a specified prefix safely.
+ *
+ * @param str The cstring to check.
+ * @param prefix The prefix to test.
+ * @param max_len Maximum characters to consider.
+ * @return 1 if the cstring starts with the prefix, 0 otherwise.
+ */
+int fossil_io_cstring_starts_with_safe(ccstring str, ccstring prefix, size_t max_len);
+
+/**
+ * @brief Checks if a cstring ends with a specified suffix safely.
+ *
+ * @param str The cstring to check.
+ * @param suffix The suffix to test.
+ * @param max_len Maximum characters to consider.
+ * @return 1 if the cstring ends with the suffix, 0 otherwise.
+ */
+int fossil_io_cstring_ends_with_safe(ccstring str, ccstring suffix, size_t max_len);
+
+/**
+ * @brief Compares two cstrings for exact equality safely.
+ *
+ * @param a First cstring.
+ * @param b Second cstring.
+ * @param max_len Maximum characters to compare.
+ * @return 1 if equal, 0 otherwise.
+ */
+int fossil_io_cstring_equals_safe(ccstring a, ccstring b, size_t max_len);
+
+/**
+ * @brief Compares two cstrings for equality ignoring case safely.
+ *
+ * @param a First cstring.
+ * @param b Second cstring.
+ * @param max_len Maximum characters to compare.
+ * @return 1 if equal ignoring case, 0 otherwise.
+ */
+int fossil_io_cstring_iequals_safe(ccstring a, ccstring b, size_t max_len);
+
+/**
+ * @brief Checks if a substring exists in a cstring ignoring case safely.
+ *
+ * @param str The cstring to search.
+ * @param substr The substring to look for.
+ * @param max_len Maximum characters to scan.
+ * @return 1 if found, 0 otherwise.
+ */
+int fossil_io_cstring_icontains_safe(ccstring str, ccstring substr, size_t max_len);
+
+/**
+ * @brief Removes surrounding quotes from a cstring safely.
+ *
+ * @param str The cstring to process.
+ * @param max_len Maximum characters to process.
+ * @return A new cstring without surrounding quotes.
+ */
+cstring fossil_io_cstring_strip_quotes_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Normalizes whitespace in a cstring safely.
+ *
+ * Collapses multiple spaces into one and trims leading/trailing whitespace.
+ *
+ * @param str The cstring to normalize.
+ * @param max_len Maximum characters to process.
+ * @return A newly allocated normalized cstring.
+ */
+cstring fossil_io_cstring_normalize_spaces_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Returns the index of a substring in a cstring safely.
+ *
+ * @param str The cstring to search.
+ * @param substr The substring to find.
+ * @param max_len Maximum characters to consider.
+ * @return Index of first occurrence, or -1 if not found.
+ */
+int fossil_io_cstring_index_of_safe(ccstring str, ccstring substr, size_t max_len);
+
 // String Stream
 
 /**
@@ -951,6 +1127,267 @@ namespace fossil {
              */
             int append(const std::string &src) {
                 return fossil_io_cstring_append(&_str, src.c_str()) == nullptr ? 1 : 0;
+            }
+            
+            /* ---------------- Safe Copy / Dup / Concat ---------------- */
+
+            /**
+             * @brief Creates a safe copy of the given string.
+             *
+             * Allocates a new CString with a copy of the input string, using the
+             * secure underlying C function to prevent buffer overflows.
+             *
+             * @param str The string to copy.
+             * @return A new CString containing a safe copy of the input string.
+             */
+            static CString copy_safe(const std::string &str) {
+                return CString(fossil_io_cstring_copy_safe(str.c_str(), str.size()));
+            }
+            
+            /**
+             * @brief Duplicates a string safely.
+             *
+             * Creates a new CString with the same content as the input string,
+             * using a secure duplication function that respects the specified length.
+             *
+             * @param str The string to duplicate.
+             * @return A new CString duplicate of the input string.
+             */
+            static CString dup_safe(const std::string &str) {
+                return CString(fossil_io_cstring_dup_safe(str.c_str(), str.size()));
+            }
+            
+            /**
+             * @brief Concatenates two strings safely.
+             *
+             * Produces a new CString containing s1 followed by s2, using the secure
+             * concatenation function and respecting the maximum allowed length.
+             *
+             * @param s1 The first string.
+             * @param s2 The second string.
+             * @param max_len Maximum length of the resulting string to prevent overflow.
+             * @return A new CString with the concatenated content.
+             */
+            static CString concat_safe(const std::string &s1, const std::string &s2, size_t max_len) {
+                return CString(fossil_io_cstring_concat_safe(s1.c_str(), s2.c_str(), max_len));
+            }
+            
+            /* ---------------- Safe Substring / Reverse / Contains ---------------- */
+            
+            /**
+             * @brief Extracts a safe substring from the CString.
+             *
+             * Uses secure substring logic to prevent reading beyond the maximum length.
+             *
+             * @param start Starting index of the substring.
+             * @param length Length of the substring.
+             * @param max_len Maximum number of characters to read from the original string.
+             * @return A new CString containing the substring.
+             */
+            CString substring_safe(size_t start, size_t length, size_t max_len) const {
+                return CString(fossil_io_cstring_substring_safe(_str, start, length, max_len));
+            }
+            
+            /**
+             * @brief Reverses the CString safely.
+             *
+             * Returns a new CString containing the reverse of the original string
+             * while respecting the maximum length.
+             *
+             * @param max_len Maximum length to process for safety.
+             * @return A new reversed CString.
+             */
+            CString reverse_safe(size_t max_len) const {
+                return CString(fossil_io_cstring_reverse_safe(_str, max_len));
+            }
+            
+            /**
+             * @brief Checks if the CString contains a substring safely.
+             *
+             * Performs a bounds-checked search within the string.
+             *
+             * @param substr The substring to search for.
+             * @param max_len Maximum number of characters to check.
+             * @return True if substring is found, false otherwise.
+             */
+            bool contains_safe(const std::string &substr, size_t max_len) const {
+                return fossil_io_cstring_contains_safe(_str, substr.c_str(), max_len) != 0;
+            }
+            
+            /* ---------------- Safe Repeat / Strip / Count ---------------- */
+            
+            /**
+             * @brief Repeats the CString a specified number of times safely.
+             *
+             * Generates a new CString that repeats the content up to max_len characters.
+             *
+             * @param count Number of repetitions.
+             * @param max_len Maximum total length of the resulting string.
+             * @return A new repeated CString.
+             */
+            CString repeat_safe(size_t count, size_t max_len) const {
+                return CString(fossil_io_cstring_repeat_safe(_str, count, max_len));
+            }
+            
+            /**
+             * @brief Strips a character from both ends of the CString safely.
+             *
+             * Produces a new CString with leading and trailing characters removed,
+             * respecting max_len for safety.
+             *
+             * @param ch The character to strip.
+             * @param max_len Maximum number of characters to consider.
+             * @return A new CString with the character stripped.
+             */
+            CString strip_safe(char ch, size_t max_len) const {
+                return CString(fossil_io_cstring_strip_safe(_str, ch, max_len));
+            }
+            
+            /**
+             * @brief Counts the number of occurrences of a substring safely.
+             *
+             * Uses a secure method that respects maximum string length.
+             *
+             * @param substr The substring to count.
+             * @param max_len Maximum number of characters to process.
+             * @return Number of occurrences of substr in the CString.
+             */
+            size_t count_safe(const std::string &substr, size_t max_len) const {
+                return fossil_io_cstring_count_safe(_str, substr.c_str(), max_len);
+            }
+            
+            /* ---------------- Safe Padding ---------------- */
+            
+            /**
+             * @brief Pads the CString on the left safely.
+             *
+             * Ensures the resulting string does not exceed max_len characters.
+             *
+             * @param total_length The total desired length after padding.
+             * @param pad_char Character to pad with.
+             * @param max_len Maximum allowed length to prevent overflow.
+             * @return A new left-padded CString.
+             */
+            CString pad_left_safe(size_t total_length, char pad_char, size_t max_len) const {
+                return CString(fossil_io_cstring_pad_left_safe(_str, total_length, pad_char, max_len));
+            }
+            
+            /**
+             * @brief Pads the CString on the right safely.
+             *
+             * Ensures the resulting string does not exceed max_len characters.
+             *
+             * @param total_length The total desired length after padding.
+             * @param pad_char Character to pad with.
+             * @param max_len Maximum allowed length to prevent overflow.
+             * @return A new right-padded CString.
+             */
+            CString pad_right_safe(size_t total_length, char pad_char, size_t max_len) const {
+                return CString(fossil_io_cstring_pad_right_safe(_str, total_length, pad_char, max_len));
+            }
+            
+            /* ---------------- Safe Prefix / Suffix ---------------- */
+            
+            /**
+             * @brief Checks if the CString starts with a prefix safely.
+             *
+             * Considers max_len for safe comparison.
+             *
+             * @param prefix The prefix to check.
+             * @param max_len Maximum number of characters to read.
+             * @return True if CString starts with prefix, false otherwise.
+             */
+            bool starts_with_safe(const std::string &prefix, size_t max_len) const {
+                return fossil_io_cstring_starts_with_safe(_str, prefix.c_str(), max_len) != 0;
+            }
+            
+            /**
+             * @brief Checks if the CString ends with a suffix safely.
+             *
+             * Considers max_len for safe comparison.
+             *
+             * @param suffix The suffix to check.
+             * @param max_len Maximum number of characters to read.
+             * @return True if CString ends with suffix, false otherwise.
+             */
+            bool ends_with_safe(const std::string &suffix, size_t max_len) const {
+                return fossil_io_cstring_ends_with_safe(_str, suffix.c_str(), max_len) != 0;
+            }
+            
+            /* ---------------- Safe Equality Checks ---------------- */
+            
+            /**
+             * @brief Checks equality safely (case-sensitive).
+             *
+             * Compares CString to another string with max_len bounds.
+             *
+             * @param other The string to compare.
+             * @param max_len Maximum characters to compare.
+             * @return True if equal, false otherwise.
+             */
+            bool equals_safe(const std::string &other, size_t max_len) const {
+                return fossil_io_cstring_equals_safe(_str, other.c_str(), max_len) != 0;
+            }
+            
+            /**
+             * @brief Checks equality safely (case-insensitive).
+             *
+             * Compares CString to another string with max_len bounds, ignoring case.
+             *
+             * @param other The string to compare.
+             * @param max_len Maximum characters to compare.
+             * @return True if equal ignoring case, false otherwise.
+             */
+            bool iequals_safe(const std::string &other, size_t max_len) const {
+                return fossil_io_cstring_iequals_safe(_str, other.c_str(), max_len) != 0;
+            }
+            
+            /**
+             * @brief Checks if CString contains a substring safely (case-insensitive).
+             *
+             * @param substr Substring to check.
+             * @param max_len Maximum characters to examine.
+             * @return True if found, false otherwise.
+             */
+            bool icontains_safe(const std::string &substr, size_t max_len) const {
+                return fossil_io_cstring_icontains_safe(_str, substr.c_str(), max_len) != 0;
+            }
+            
+            /* ---------------- Safe Quotes / Whitespace / Index ---------------- */
+            
+            /**
+             * @brief Removes surrounding quotes safely.
+             *
+             * Considers max_len and removes only leading/trailing single or double quotes.
+             *
+             * @param max_len Maximum characters to process.
+             * @return A new CString with quotes removed.
+             */
+            CString strip_quotes_safe(size_t max_len) const {
+                return CString(fossil_io_cstring_strip_quotes_safe(_str, max_len));
+            }
+            
+            /**
+             * @brief Normalizes spaces safely.
+             *
+             * Collapses multiple consecutive spaces into one, respecting max_len.
+             *
+             * @param max_len Maximum characters to process.
+             * @return A new CString with normalized spaces.
+             */
+            CString normalize_spaces_safe(size_t max_len) const {
+                return CString(fossil_io_cstring_normalize_spaces_safe(_str, max_len));
+            }
+            
+            /**
+             * @brief Finds the index of a substring safely.
+             *
+             * @param substr Substring to find.
+             * @param max_len Maximum characters to search.
+             * @return Index of substring or -1 if not found.
+             */
+            int index_of_safe(const std::string &substr, size_t max_len) const {
+                return fossil_io_cstring_index_of_safe(_str, substr.c_str(), max_len);
             }
 
             /**

--- a/code/logic/fossil/io/cstring.h
+++ b/code/logic/fossil/io/cstring.h
@@ -351,6 +351,191 @@ cstring fossil_io_cstring_strip_quotes(ccstring str);
  */
 cstring fossil_io_cstring_append(cstring *dest, ccstring src);
 
+// Secure String 
+
+/**
+ * @brief Creates a new cstring with the given initial value safely.
+ *
+ * Allocates a new buffer for the string, ensuring null-termination.
+ *
+ * @param init The initial value for the cstring.
+ * @return A new cstring initialized with the given value, or NULL on failure.
+ */
+cstring fossil_io_cstring_create_safe(const char *init, size_t max_len);
+
+/**
+ * @brief Frees a cstring safely.
+ *
+ * Sets the pointer to NULL after freeing to prevent dangling references.
+ *
+ * @param str Pointer to the cstring to free.
+ */
+void fossil_io_cstring_free_safe(cstring *str);
+
+/**
+ * @brief Creates a safe copy of the given cstring.
+ *
+ * @param str The cstring to copy.
+ * @param max_len Maximum number of characters to copy.
+ * @return A newly allocated cstring copy, or NULL on failure.
+ */
+cstring fossil_io_cstring_copy_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Duplicates the given cstring safely.
+ *
+ * @param str The cstring to duplicate.
+ * @param max_len Maximum number of characters to duplicate.
+ * @return A newly allocated duplicate cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_dup_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Concatenates two cstrings safely.
+ *
+ * Ensures that the resulting string is null-terminated and does not overflow.
+ *
+ * @param s1 First cstring.
+ * @param s2 Second cstring.
+ * @param max_len Maximum allowed length of the resulting string.
+ * @return A new concatenated cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_concat_safe(ccstring s1, ccstring s2, size_t max_len);
+
+/**
+ * @brief Returns the length of the given cstring safely.
+ *
+ * Ensures that the string is properly null-terminated within max_len.
+ *
+ * @param str The cstring whose length is determined.
+ * @param max_len Maximum characters to scan.
+ * @return The length of the cstring up to max_len.
+ */
+size_t fossil_io_cstring_length_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Compares two cstrings safely.
+ *
+ * Ensures no buffer overrun; comparison stops at max_len or null terminator.
+ *
+ * @param s1 First cstring.
+ * @param s2 Second cstring.
+ * @param max_len Maximum characters to compare.
+ * @return <0 if s1<s2, 0 if equal, >0 if s1>s2
+ */
+int fossil_io_cstring_compare_safe(ccstring s1, ccstring s2, size_t max_len);
+
+/**
+ * @brief Safely concatenates src to dest in-place with bounds checking.
+ *
+ * Resizes the buffer as needed. Ensures null-termination.
+ *
+ * @param dest Pointer to destination cstring.
+ * @param src Source cstring to append.
+ * @param max_len Maximum allowed length for dest after append.
+ * @return 0 on success, non-zero on failure.
+ */
+int fossil_io_cstring_append_safe(cstring *dest, ccstring src, size_t max_len);
+
+/**
+ * @brief Trims whitespace safely from a cstring.
+ *
+ * Ensures null-termination and modifies in-place or allocates a new string.
+ *
+ * @param str The cstring to trim.
+ * @param max_len Maximum length of the string to process.
+ */
+cstring fossil_io_cstring_trim_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Splits a cstring safely by a delimiter.
+ *
+ * Allocates an array of strings, each safely null-terminated.
+ *
+ * @param str The string to split.
+ * @param delimiter Character to split by.
+ * @param count Pointer to store number of substrings.
+ * @param max_len Maximum length of each substring.
+ * @return Array of safe cstrings, or NULL on failure.
+ */
+cstring *fossil_io_cstring_split_safe(ccstring str, char delimiter, size_t *count, size_t max_len);
+
+/**
+ * @brief Replaces all occurrences of a substring safely.
+ *
+ * Allocates a new string and ensures null-termination.
+ *
+ * @param str Original string.
+ * @param old Substring to replace.
+ * @param new_str Replacement substring.
+ * @param max_len Maximum length of resulting string.
+ * @return A new cstring with replacements, or NULL on failure.
+ */
+cstring fossil_io_cstring_replace_safe(ccstring str, ccstring old, ccstring new_str, size_t max_len);
+
+/**
+ * @brief Converts a cstring to uppercase safely.
+ *
+ * Allocates a new string, ensures null-termination.
+ *
+ * @param str The cstring to convert.
+ * @param max_len Maximum allowed length.
+ * @return Uppercase cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_to_upper_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Converts a cstring to lowercase safely.
+ *
+ * @param str The cstring to convert.
+ * @param max_len Maximum allowed length.
+ * @return Lowercase cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_to_lower_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Safely creates a formatted cstring.
+ *
+ * Allocates enough memory for the resulting string; guarantees null-termination.
+ *
+ * @param max_len Maximum length for formatted string.
+ * @param format Format string.
+ * @param ... Format arguments.
+ * @return Newly allocated formatted cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_format_safe(size_t max_len, ccstring format, ...);
+
+/**
+ * @brief Safely joins multiple strings with a delimiter.
+ *
+ * @param strings Array of cstrings.
+ * @param count Number of elements.
+ * @param delimiter Character to insert.
+ * @param max_len Maximum allowed length of resulting string.
+ * @return New cstring or NULL on failure.
+ */
+cstring fossil_io_cstring_join_safe(ccstring *strings, size_t count, char delimiter, size_t max_len);
+
+/**
+ * @brief Safely escapes a cstring for JSON output.
+ *
+ * Ensures resulting string is null-terminated and memory-safe.
+ *
+ * @param str Input cstring.
+ * @param max_len Maximum length of resulting escaped string.
+ * @return Escaped cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_escape_json_safe(ccstring str, size_t max_len);
+
+/**
+ * @brief Safely unescapes a JSON-escaped cstring.
+ *
+ * @param str JSON-escaped string.
+ * @param max_len Maximum length of resulting string.
+ * @return Unescaped cstring, or NULL on failure.
+ */
+cstring fossil_io_cstring_unescape_json_safe(ccstring str, size_t max_len);
+
 // String Stream
 
 /**


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description
Cstring API has been extended to include safe secure versions of the existing API to protect against buffer overflow, string stream extended, both classes updated to include new API functionality.

## Testing
New test cases via Fossil Test

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
