### PR TITLE
Add input api key binding

### DIFF
--- a/code/logic/fossil/io/input.h
+++ b/code/logic/fossil/io/input.h
@@ -172,6 +172,67 @@ void fossil_io_show_progress(int progress);
  */
 int fossil_io_gets(char *buffer, size_t size);
 
+/**
+ * @brief Type for representing a key binding.
+ */
+typedef struct {
+    int key_code;           /**< The integer key code (e.g., ASCII or special code). */
+    const char *action;     /**< The action associated with this key (e.g., "COPY", "PASTE"). */
+} fossil_io_keybinding_t;
+
+/**
+ * @brief Registers a new key binding.
+ *
+ * Adds a key-action mapping to the input library.
+ *
+ * @param key_code The integer key code to bind.
+ * @param action The action string associated with the key.
+ * @return 0 on success, non-zero on failure (e.g., duplicate key).
+ */
+int fossil_io_register_keybinding(int key_code, const char *action);
+
+/**
+ * @brief Removes an existing key binding.
+ *
+ * @param key_code The key code of the binding to remove.
+ * @return 0 on success, non-zero if the key was not found.
+ */
+int fossil_io_unregister_keybinding(int key_code);
+
+/**
+ * @brief Retrieves the action associated with a key code.
+ *
+ * @param key_code The key code to look up.
+ * @return The action string if found, NULL otherwise.
+ */
+const char* fossil_io_get_keybinding_action(int key_code);
+
+/**
+ * @brief Processes a key event.
+ *
+ * Checks if a key has a registered action and triggers it if found.
+ *
+ * @param key_code The key code that was pressed.
+ * @return 1 if an action was triggered, 0 if no binding exists.
+ */
+int fossil_io_process_keybinding(int key_code);
+
+/**
+ * @brief Lists all currently registered key bindings.
+ *
+ * @param bindings Array of fossil_io_keybinding_t to populate.
+ * @param max_bindings Maximum number of bindings to populate.
+ * @return Number of bindings populated in the array.
+ */
+size_t fossil_io_list_keybindings(fossil_io_keybinding_t *bindings, size_t max_bindings);
+
+/**
+ * @brief Clears all registered key bindings.
+ *
+ * Frees any internal memory and removes all key-action mappings.
+ */
+void fossil_io_clear_keybindings(void);
+
 #ifdef __cplusplus
 }
 

--- a/code/logic/fossil/io/input.h
+++ b/code/logic/fossil/io/input.h
@@ -236,6 +236,13 @@ void fossil_io_clear_keybindings(void);
 #ifdef __cplusplus
 }
 
+#include <cstddef>
+#include <string>
+#include <vector>
+#include <utility>
+#include <cstdarg>
+#include <istream>
+
 /**
  * Namespace for the Fossil Logic I/O library.
  */
@@ -456,6 +463,82 @@ namespace fossil {
                 input_stream.getline(buffer, sizeof(buffer));
                 // Process the buffer as needed to populate the Input object.
                 return input_stream;
+            }
+
+            /**
+             * Registers a key binding with an associated action string.
+             *
+             * @param key_code The integer key code.
+             * @param action The action string to associate with the key.
+             * @return 0 on success, non-zero on failure.
+             */
+            static int register_keybinding(int key_code, const std::string &action) {
+                return fossil_io_register_keybinding(key_code, action.c_str());
+            }
+
+            /**
+             * Registers a key binding with an optional callback function.
+             *
+             * @param key_code The integer key code.
+             * @param action The action string to associate with the key.
+             * @param callback Function pointer to execute when the key is pressed.
+             * @return 0 on success, non-zero on failure.
+             */
+            static int register_keybinding_callback(int key_code, const std::string &action, void (*callback)()) {
+                return fossil_io_register_keybinding_with_callback(key_code, action.c_str(), callback);
+            }
+
+            /**
+             * Unregisters a key binding.
+             *
+             * @param key_code The key code of the binding to remove.
+             * @return 0 on success, non-zero if the key was not found.
+             */
+            static int unregister_keybinding(int key_code) {
+                return fossil_io_unregister_keybinding(key_code);
+            }
+
+            /**
+             * Processes a key event.
+             *
+             * @param key_code The key code to process.
+             * @return 1 if an action was triggered, 0 if no binding exists.
+             */
+            static int process_keybinding(int key_code) {
+                return fossil_io_process_keybinding(key_code);
+            }
+
+            /**
+             * Retrieves the action associated with a key code.
+             *
+             * @param key_code The key code to look up.
+             * @return The action string if found, empty string otherwise.
+             */
+            static std::string get_keybinding_action(int key_code) {
+                const char *action = fossil_io_get_keybinding_action(key_code);
+                return action ? std::string(action) : std::string();
+            }
+
+            /**
+             * Lists all registered key bindings.
+             *
+             * @return A vector of key-action pairs representing all bindings.
+             */
+            static std::vector<std::pair<int, std::string>> list_keybindings() {
+                std::vector<std::pair<int, std::string>> bindings;
+                fossil_io_keybinding_t arr[256];
+                size_t count = fossil_io_list_keybindings(arr, 256);
+                for (size_t i = 0; i < count; i++) {
+                    bindings.emplace_back(arr[i].key_code, arr[i].action ? arr[i].action : "");
+                }
+                return bindings;
+            }
+
+            /**
+             * Clears all registered key bindings.
+             */
+            static void clear_keybindings() {
+                fossil_io_clear_keybindings();
             }
 
         };

--- a/code/logic/input.c
+++ b/code/logic/input.c
@@ -315,3 +315,108 @@ int fossil_io_gets(char *buffer, size_t size) {
     }
     return 0; // Success
 }
+
+typedef void (*fossil_io_action_callback_t)(void);
+
+typedef struct {
+    int key_code;                         /**< The integer key code (e.g., ASCII or special code). */
+    const char *action;                    /**< The action string associated with this key. */
+    fossil_io_action_callback_t callback;  /**< Optional function to call when key is pressed. */
+} fossil_io_keybinding_t;
+
+#define MAX_KEYBINDINGS 256
+static fossil_io_keybinding_t _keybindings[MAX_KEYBINDINGS];
+static size_t _num_keybindings = 0;
+
+int fossil_io_register_keybinding(int key_code, const char *action) {
+    if (!action || _num_keybindings >= MAX_KEYBINDINGS) return 1;
+
+    // Check for duplicate
+    for (size_t i = 0; i < _num_keybindings; i++) {
+        if (_keybindings[i].key_code == key_code) return 2; // Duplicate key
+    }
+
+    _keybindings[_num_keybindings].key_code = key_code;
+    _keybindings[_num_keybindings].action = strdup(action);
+    if (!_keybindings[_num_keybindings].action) return 3; // Allocation failure
+
+    _num_keybindings++;
+    return 0;
+}
+
+int fossil_io_unregister_keybinding(int key_code) {
+    for (size_t i = 0; i < _num_keybindings; i++) {
+        if (_keybindings[i].key_code == key_code) {
+            free((void*)_keybindings[i].action);
+            // Shift remaining bindings
+            for (size_t j = i; j < _num_keybindings - 1; j++) {
+                _keybindings[j] = _keybindings[j + 1];
+            }
+            _num_keybindings--;
+            return 0;
+        }
+    }
+    return 1; // Key not found
+}
+
+const char* fossil_io_get_keybinding_action(int key_code) {
+    for (size_t i = 0; i < _num_keybindings; i++) {
+        if (_keybindings[i].key_code == key_code) {
+            return _keybindings[i].action;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * Registers a new key binding with optional callback.
+ */
+int fossil_io_register_keybinding_with_callback(int key_code, const char *action, fossil_io_action_callback_t cb) {
+    if (!action || _num_keybindings >= MAX_KEYBINDINGS) return 1;
+
+    // Check for duplicate key
+    for (size_t i = 0; i < _num_keybindings; i++) {
+        if (_keybindings[i].key_code == key_code) return 2; // Duplicate
+    }
+
+    _keybindings[_num_keybindings].key_code = key_code;
+    _keybindings[_num_keybindings].action = strdup(action);
+    _keybindings[_num_keybindings].callback = cb;
+    if (!_keybindings[_num_keybindings].action) return 3; // Allocation failed
+
+    _num_keybindings++;
+    return 0;
+}
+
+/**
+ * Enhanced key processing that calls registered callback.
+ */
+int fossil_io_process_keybinding(int key_code) {
+    for (size_t i = 0; i < _num_keybindings; i++) {
+        if (_keybindings[i].key_code == key_code) {
+            if (_keybindings[i].callback) {
+                _keybindings[i].callback();  // Execute callback
+            } else {
+                printf("Action triggered: %s\n", _keybindings[i].action);
+            }
+            return 1; // Action processed
+        }
+    }
+    return 0; // No binding
+}
+
+size_t fossil_io_list_keybindings(fossil_io_keybinding_t *bindings, size_t max_bindings) {
+    size_t count = (max_bindings < _num_keybindings) ? max_bindings : _num_keybindings;
+    for (size_t i = 0; i < count; i++) {
+        bindings[i].key_code = _keybindings[i].key_code;
+        bindings[i].action = _keybindings[i].action;
+    }
+    return count;
+}
+
+void fossil_io_clear_keybindings(void) {
+    for (size_t i = 0; i < _num_keybindings; i++) {
+        free((void*)_keybindings[i].action);
+    }
+    _num_keybindings = 0;
+}


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description
Adding key bindings capabilities to input API to allow key bindings within command line tools.

## Testing
New cases for key bindings

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
