### PR TITLE
Soap extend patch

### DIFF
--- a/code/logic/fossil/io/soap.h
+++ b/code/logic/fossil/io/soap.h
@@ -14,6 +14,7 @@
 #ifndef FOSSIL_IO_SOAP_H
 #define FOSSIL_IO_SOAP_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 

--- a/code/logic/fossil/io/soap.h
+++ b/code/logic/fossil/io/soap.h
@@ -106,40 +106,75 @@ int fossil_io_soap_detect_exaggeration(const char *text);
  */
 char *fossil_io_soap_filter_offensive(const char *text);
 
-/**
- * Detects whether the given text contains ragebait phrases.
- *
- * Ragebait phrases are text patterns designed to provoke anger,
- * outrage, or strong emotional reactions in the reader.
- *
- * @param text The input C string to analyze.
- * @return 1 if any ragebait phrase is detected, 0 otherwise.
+/** 
+ * Detects ragebait content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if ragebait patterns are found, 0 otherwise.
  */
 int fossil_io_soap_detect_ragebait(const char *text);
 
-/**
- * @brief Check if input contains clickbait-style language.
- *
- * @param text The input string.
- * @return 1 if clickbait is detected, 0 otherwise.
+/** 
+ * Detects clickbait content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if clickbait patterns are found, 0 otherwise.
  */
 int fossil_io_soap_detect_clickbait(const char *text);
 
-/**
- * @brief Detects if a given text contains spammy patterns
- *
- * @param text Input string to analyze
- * @return 1 if spam detected, 0 otherwise
+/** 
+ * Detects spam content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if spam patterns are found, 0 otherwise.
  */
 int fossil_io_soap_detect_spam(const char *text);
 
-/**
- * @brief Detects if a given text contains "woke" tone patterns
- *
- * @param text Input string to analyze
- * @return 1 if woke tone detected, 0 otherwise
+/** 
+ * Detects woke-related content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if woke patterns are found, 0 otherwise.
  */
 int fossil_io_soap_detect_woke(const char *text);
+
+/** 
+ * Detects propaganda content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if propaganda patterns are found, 0 otherwise.
+ */
+int fossil_io_soap_detect_propaganda(const char *text);
+
+/** 
+ * Detects automated/bot content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if bot patterns are found, 0 otherwise.
+ */
+int fossil_io_soap_detect_bot(const char *text);
+
+/** 
+ * Detects fake news content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if fake news patterns are found, 0 otherwise.
+ */
+int fossil_io_soap_detect_fake_news(const char *text);
+
+/** 
+ * Detects sarcastic tone in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if sarcastic patterns are found, 0 otherwise.
+ */
+int fossil_io_soap_detect_sarcasm(const char *text);
+
+/** 
+ * Detects formal tone in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if formal patterns are found, 0 otherwise.
+ */
+int fossil_io_soap_detect_formal(const char *text);
+
+/** 
+ * Detects "snowflake"-related content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if snowflake patterns are found, 0 otherwise.
+ */
+int fossil_io_soap_detect_snowflake(const char *text);
 
 #ifdef __cplusplus
 }

--- a/code/logic/fossil/io/soap.h
+++ b/code/logic/fossil/io/soap.h
@@ -30,6 +30,32 @@ extern "C" {
 char *fossil_io_soap_sanitize(const char *text);
 
 /**
+ * Scan the text for any match in the given patterns array.
+ * @param text Input text to analyze.
+ * @param patterns NULL-terminated array of string patterns.
+ * @return Non-zero if any pattern is found, 0 otherwise.
+ */
+int soap_detect_patterns(const char *text, const char **patterns);
+
+/**
+ * Detect a specific SOAP category in the text.
+ * @param text Input text to analyze.
+ * @param category SOAP category enum.
+ * @return Non-zero if any pattern in the category is found, 0 otherwise.
+ */
+int fossil_io_soap_detect_category(const char *text, soap_category_t category);
+
+/**
+ * Detect multiple categories in the text.
+ * @param text Input text to analyze.
+ * @param categories Array of category enums to check.
+ * @param count Number of categories in the array.
+ * @param out_matches Optional output array (bool[count]) to store matches per category.
+ * @return Number of categories matched.
+ */
+int fossil_io_soap_detect_multiple(const char *text, const soap_category_t *categories, int count, bool *out_matches);
+
+/**
  * @brief Suggest proper alternatives for rot-brain words or grammar fixes.
  *
  * @param text The input text.

--- a/code/logic/fossil/io/soap.h
+++ b/code/logic/fossil/io/soap.h
@@ -202,6 +202,13 @@ int fossil_io_soap_detect_formal(const char *text);
  */
 int fossil_io_soap_detect_snowflake(const char *text);
 
+/** 
+ * Detects "offensive"-related content in the given text.
+ * @param text Input string to analyze.
+ * @return Non-zero if offensive patterns are found, 0 otherwise.
+ */
+int fossil_io_soap_detect_offensive(const char *text);
+
 #ifdef __cplusplus
 }
 

--- a/code/logic/fossil/io/soap.h
+++ b/code/logic/fossil/io/soap.h
@@ -125,6 +125,22 @@ int fossil_io_soap_detect_ragebait(const char *text);
  */
 int fossil_io_soap_detect_clickbait(const char *text);
 
+/**
+ * @brief Detects if a given text contains spammy patterns
+ *
+ * @param text Input string to analyze
+ * @return 1 if spam detected, 0 otherwise
+ */
+int fossil_io_soap_detect_spam(const char *text);
+
+/**
+ * @brief Detects if a given text contains "woke" tone patterns
+ *
+ * @param text Input string to analyze
+ * @return 1 if woke tone detected, 0 otherwise
+ */
+int fossil_io_soap_detect_woke(const char *text);
+
 #ifdef __cplusplus
 }
 

--- a/code/logic/fossil/io/soap.h
+++ b/code/logic/fossil/io/soap.h
@@ -1,4 +1,4 @@
-/*
+/**
  * -----------------------------------------------------------------------------
  * Project: Fossil Logic
  *
@@ -28,14 +28,6 @@ extern "C" {
  * @return A dynamically allocated sanitized string (must be freed by the caller).
  */
 char *fossil_io_soap_sanitize(const char *text);
-
-/**
- * Scan the text for any match in the given patterns array.
- * @param text Input text to analyze.
- * @param patterns NULL-terminated array of string patterns.
- * @return Non-zero if any pattern is found, 0 otherwise.
- */
-int soap_detect_patterns(const char *text, const char **patterns);
 
 /**
  * Detect a specific SOAP category in the text.

--- a/code/logic/fossil/io/soap.h
+++ b/code/logic/fossil/io/soap.h
@@ -31,24 +31,6 @@ extern "C" {
 char *fossil_io_soap_sanitize(const char *text);
 
 /**
- * Detect a specific SOAP category in the text.
- * @param text Input text to analyze.
- * @param category SOAP category enum.
- * @return Non-zero if any pattern in the category is found, 0 otherwise.
- */
-int fossil_io_soap_detect_category(const char *text, soap_category_t category);
-
-/**
- * Detect multiple categories in the text.
- * @param text Input text to analyze.
- * @param categories Array of category enums to check.
- * @param count Number of categories in the array.
- * @param out_matches Optional output array (bool[count]) to store matches per category.
- * @return Number of categories matched.
- */
-int fossil_io_soap_detect_multiple(const char *text, const soap_category_t *categories, int count, bool *out_matches);
-
-/**
  * @brief Suggest proper alternatives for rot-brain words or grammar fixes.
  *
  * @param text The input text.

--- a/code/logic/fossil/io/soap.h
+++ b/code/logic/fossil/io/soap.h
@@ -283,6 +283,26 @@ namespace fossil {
             static bool is_clickbait(const std::string &text) {
                 return fossil_io_soap_detect_clickbait(text.c_str()) != 0;
             }
+            
+            /**
+             * @brief Detects if a given text contains spammy patterns
+             *
+             * @param text Input string to analyze
+             * @return 1 if spam detected, 0 otherwise
+             */
+            static int is_spam(const std::string &text){
+                return fossil_io_soap_detect_spam(text.c_str()) != 0;
+            }
+            
+            /**
+             * @brief Detects if a given text contains "woke" tone patterns
+             *
+             * @param text Input string to analyze
+             * @return 1 if woke tone detected, 0 otherwise
+             */
+            static int is_woke(const std::string &text){
+                return fossil_io_soap_detect_woke(text.c_str()) != 0;
+            }
 
             /**
              * @brief Normalize slang and internet abbreviations.

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -546,28 +546,6 @@ static int soap_detect_patterns(const char *text, const char **patterns) {
     return 0; // No match
 }
 
-int fossil_io_soap_detect_category(const char *text, soap_category_t category) {
-    if (category >= SOAP_CAT_COUNT) return 0;
-    return SOAP_DETECTORS[category].detect_fn(text);
-}
-
-int fossil_io_soap_detect_multiple(const char *text, const soap_category_t *categories, int count, bool *out_matches) {
-    if (!text || !categories || count <= 0) return 0;
-
-    int matches = 0;
-    for (int i = 0; i < count; i++) {
-        int detected = 0;
-        if (categories[i] < SOAP_CAT_COUNT) {
-            detected = SOAP_DETECTORS[categories[i]].detect_fn(text);
-        }
-
-        if (out_matches) out_matches[i] = detected ? true : false;
-        if (detected) matches++;
-    }
-
-    return matches;
-}
-
 /**
  * @brief Sanitize input text by removing or replacing "rot-brain" and meme-based language.
  * @param censor_char Character to use for censored words (e.g., "*" or "#").

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -185,7 +185,7 @@ static const char *SOAP_SARCASTIC_PATTERNS[] = {
 };
 
 /** Lookup table for formal phrases */
-static const char *SOAP_FORMAL_PATTERS[] = {
+static const char *SOAP_FORMAL_PATTERNS[] = {
     "Dear Sir or Madam", "To whom it may concern", "Yours sincerely", "Yours faithfully",
     "Best regards", "Respectfully", "I would like to", "I am writing to",
     "Please find attached", "Thank you for your consideration", "I look forward to your response",

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -38,10 +38,10 @@ typedef int (*soap_detector_fn)(const char *text);
 
 // Detector registry entry
 typedef struct {
-    soap_category_t category;      // Category
-    const char *name;              // Human-readable name
+    soap_category_t category;     // Category
+    const char *name;             // Human-readable name
     const char **patterns;         // Lookup table of phrases
-    soap_detector_fn detect;       // Optional custom function
+    soap_detector_fn detector;     // Optional custom function
 } soap_detector_t;
 
 // Optional: reasoning / TI metadata

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -21,6 +21,36 @@
 
 #define MAX_CUSTOM_FILTERS 64
 
+// Category enum
+typedef enum {
+    SOAP_CAT_RAGEBAIT,
+    SOAP_CAT_CLICKBAIT,
+    SOAP_CAT_SPAM,
+    SOAP_CAT_WOKE,
+    SOAP_CAT_PROPAGANDA,
+    SOAP_CAT_BOT,
+    SOAP_CAT_FAKE_NEWS,
+    SOAP_CAT_COUNT   // Sentinel
+} soap_category_t;
+
+// Detector function type
+typedef int (*soap_detector_fn)(const char *text);
+
+// Detector registry entry
+typedef struct {
+    soap_category_t category;      // Category
+    const char *name;              // Human-readable name
+    const char **patterns;         // Lookup table of phrases
+    soap_detector_fn detect;       // Optional custom function
+} soap_detector_t;
+
+// Optional: reasoning / TI metadata
+typedef struct {
+    const char *category_name;
+    const char *matched_pattern;
+    int confidence; // 0-100
+} soap_ti_reason_t;
+
 /** Lookup table for rot-brain words and their suggested replacements */
 static const struct {
     const char *bad;
@@ -143,203 +173,96 @@ static const struct {
 };
 
 /** Lookup table for sarcastic phrases */
-static const char *SARCASTIC_PHRASES[] = {
-    "Oh, great",
-    "Yeah, right",
-    "Nice job",
-    "Well done",
-    "Good luck with that",
-    "Sure, why not",
-    "Fantastic",
-    "Brilliant",
-    "Wonderful",
-    "Perfect",
-    "Oh, just what I needed",
-    "Wow, amazing",
-    "How original",
-    "Incredible",
-    "As if that will work",
-    "Sure, that's smart",
-    "Totally believable",
-    "Oh, really?",
-    "You're a genius",
-    "Thanks a lot",
-    "Couldn't be better",
-    "That's exactly what I wanted",
-    "Well, isn't that special",
-    "Lovely",
-    "Just perfect",
-    "What could go wrong?",
-    "Right, because that makes sense",
-    NULL // Sentinel to mark the end
+static const char *SOAP_SARCASTIC_PATTERNS[] = {
+    "Oh, great", "Yeah, right", "Nice job", "Well done", "Good luck with that",
+    "Sure, why not", "Fantastic", "Brilliant", "Wonderful", "Perfect",
+    "Oh, just what I needed", "Wow, amazing", "How original", "Incredible",
+    "As if that will work", "Sure, that's smart", "Totally believable",
+    "Oh, really?", "You're a genius", "Thanks a lot",
+    "Couldn't be better", "That's exactly what I wanted", "Well, isn't that special",
+    "Lovely", "Just perfect", "What could go wrong?", "Right, because that makes sense",
+    "Great idea", "Absolutely flawless", "Marvelous", "Just wonderful", NULL
 };
 
 /** Lookup table for formal phrases */
-static const char *FORMAL_PHRASES[] = {
-    "Dear Sir or Madam",
-    "To whom it may concern",
-    "Yours sincerely",
-    "Yours faithfully",
-    "Best regards",
-    "Respectfully",
-    "I would like to",
-    "I am writing to",
-    "Please find attached",
-    "Thank you for your consideration",
-    "I look forward to your response",
-    "Kindly note",
-    "Please be advised",
-    "It is my pleasure to",
-    "I would appreciate your assistance",
-    "Should you require any further information",
-    "I remain at your disposal",
-    "With kind regards",
-    "Thank you for your attention",
-    "I am writing on behalf of",
-    "Please accept my apologies",
-    "I wish to inform you",
-    "We would be grateful if",
-    "I hope this message finds you well",
-    NULL // Sentinel to mark the end
+static const char *SOAP_FORMAL_PATTERS[] = {
+    "Dear Sir or Madam", "To whom it may concern", "Yours sincerely", "Yours faithfully",
+    "Best regards", "Respectfully", "I would like to", "I am writing to",
+    "Please find attached", "Thank you for your consideration", "I look forward to your response",
+    "Kindly note", "Please be advised", "It is my pleasure to", "I would appreciate your assistance",
+    "Should you require any further information", "I remain at your disposal", "With kind regards",
+    "Thank you for your attention", "I am writing on behalf of", "Please accept my apologies",
+    "I wish to inform you", "We would be grateful if", "I hope this message finds you well",
+    "I would be obliged if", "Kindly consider", "I trust this finds you well", "Allow me to express",
+    "With utmost respect", "Permit me to", NULL
 };
 
-static const char *CLICKBAIT_PATTERNS[] = {
-    "you won't believe",
-    "shocking",
-    "what happened next",
-    "top [0-9]",
-    "things you didn't know",
-    "one weird trick",
-    "will blow your mind",
-    "can't handle this",
-    "before you die",
-    "this is why",
-    "the reason is shocking",
-    "you need to see",
-    "never guess",
-    "what they found",
-    "will surprise you",
-    "what no one tells you",
-    "you'll never believe",
-    "this changes everything",
-    "x things you should know",
-    "you won't expect",
-    "hidden secret",
-    "finally revealed",
-    "the truth about",
-    "this is insane",
-    "what happens next will amaze you",
+static const char *SOAP_RAGEBAIT_PATTERNS[] = {
+    "you won't believe", "outrageous", "infuriating", "makes me angry",
+    "how dare they", "ridiculous", "unbelievable", "trigger warning",
+    "enraging", "shocking injustice", "furious", "disgusting", "outrage",
+    "unacceptable", "appalling", "scandalous", "outraged", "angry reaction",
+    "horrifying", "outrage alert", "infuriated", "rage induced",
+    "madness", "shocking", "unthinkable", "angry outrage", "outrage fest",
+    "provocative", "furious outrage", "triggered", NULL
+};
+
+static const char *SOAP_CLICKBAIT_PATTERNS[] = {
+    "how to", "top 10", "amazing", "must see", "you won't believe what happened",
+    "life changing", "secret revealed", "uncovered", "incredible", "mind blown",
+    "you won't believe this", "shocking", "insane", "epic", "ultimate guide",
+    "hidden truth", "never knew", "reveal", "best ever", "fantastic",
+    "jaw dropping", "you must see", "exclusive", "surprising", "unreal",
+    "best of", "amazing discovery", "life hack", "can't miss", "insider tips",
     NULL
 };
 
-static const char *RAGEBAIT_PATTERNS[] = {
-    "you won't believe",
-    "infuriating",
-    "makes me angry",
-    "outrageous",
-    "how dare they",
-    "unbelievable",
-    "ridiculous",
-    "trigger warning",
-    "enraging",
-    "shocking injustice",
-    "this will anger you",
-    "prepare to be outraged",
-    "makes no sense",
-    "disgusting",
-    "furious",
-    "utterly unacceptable",
-    "outrage",
-    "you won't forgive",
-    "shocking betrayal",
-    "how could they",
-    "beyond belief",
-    "makes my blood boil",
-    "appalling",
-    "you'll be mad",
-    "infuriated by",
-    "outrageously unfair",
-    "absurd",
-    "scandalous",
-    "unacceptable",
-    "utter nonsense",
-    "provoking anger",
-    "makes me furious",
-    NULL // Sentinel
-};
-
-// Expanded spammy phrase patterns
 static const char *SOAP_SPAM_PATTERNS[] = {
-    // Generic spam
-    "free money",
-    "work from home",
-    "earn cash fast",
-    "make money online",
-    "quick cash",
-    "get rich quick",
-    "increase followers",
-    "buy now",
-    "limited time offer",
-    "act now",
-    "click here",
-    "exclusive deal",
-
-    // Health/Scam spam
-    "lose weight fast",
-    "miracle cure",
-    "anti aging",
-    "magic pill",
-    "instant results",
-
-    // Financial spam
-    "guaranteed income",
-    "credit repair",
-    "low interest rate",
-    "investment opportunity",
-    "winner",
-    "lottery",
-    "claim your prize",
-    "100% free",
-    "no risk",
-
-    // Symbols/spam tricks
-    "$$$",
-    "###",
-    "!!!",
-    NULL
+    "free money", "work from home", "act now", "earn cash fast", "get rich quick",
+    "limited time offer", "buy now", "exclusive deal", "instant results", "100% free",
+    "click here", "apply now", "offer expires", "make money online", "risk free",
+    "guaranteed", "easy income", "double your money", "urgent", "special promotion",
+    "no investment", "limited offer", "win big", "free trial", "claim prize",
+    "extra cash", "instant payout", "hot deal", "bonus", "cash bonus", NULL
 };
 
-// Expanded woke-tone phrase patterns
 static const char *SOAP_WOKE_PATTERNS[] = {
-    // Identity & equity
-    "diversity and inclusion",
-    "equity over equality",
-    "social justice",
-    "systemic oppression",
-    "white privilege",
-    "check your privilege",
-    "lived experience",
-    "cultural appropriation",
+    "safe space", "microaggression", "check your privilege", "diversity and inclusion",
+    "equity over equality", "social justice", "systemic oppression", "cultural appropriation",
+    "intersectionality", "allyship", "gender equality", "anti-racism", "inclusive language",
+    "oppression", "privilege check", "marginalized voices", "bias awareness", "equity",
+    "discrimination", "social activism", "representation matters", "critical race theory",
+    "minority rights", "empowerment", "identity politics", "decolonize", "bias training",
+    "social equity", "inclusive policy", "identity awareness", NULL
+};
 
-    // Gender & sexuality
-    "gender identity",
-    "gender fluid",
-    "non-binary",
-    "pronouns",
-    "misgender",
-    "deadname",
-    "trans rights",
+static const char *SOAP_PROPAGANDA_PATTERNS[] = {
+    "state controlled", "enemy of the people", "propaganda", "hidden agenda",
+    "government lies", "manipulated media", "biased reporting", "indoctrination",
+    "fake narrative", "misinformation", "censorship", "manipulative", "brainwashing",
+    "political agenda", "controlled press", "fabricated story", "influenced news",
+    "spinning the facts", "media bias", "deception", "false narrative", "manipulated opinion",
+    "state narrative", "hidden motives", "truth distortion", "media propaganda",
+    "agenda driven", "false headlines", "information control", "media manipulation", NULL
+};
 
-    // Safety & sensitivity
-    "safe space",
-    "trigger warning",
-    "microaggression",
-    "toxic masculinity",
-    "patriarchy",
-    "mansplaining",
-    "intersectionality",
+static const char *SOAP_BOT_PATTERNS[] = {
+    "automated message", "generated content", "bot detected", "scripted response",
+    "robot account", "auto-generated", "spam bot", "bot activity", "synthetic post",
+    "automation detected", "fake account", "bot interaction", "robotic reply", "spam account",
+    "automation bot", "ai generated", "bot behavior", "scripted content", "robotic message",
+    "automated post", "fake user", "mass message", "bot network", "automated reply",
+    "auto reply", "bot comment", "robot post", "fake bot", "automated comment", "bot spam", NULL
+};
 
-    NULL
+static const char *SOAP_FAKE_NEWS_PATTERNS[] = {
+    "breaking news", "shocking revelation", "unverified report", "fact check",
+    "false report", "misleading headline", "fabricated story", "hoax", "viral misinformation",
+    "fake article", "rumor", "clickbait news", "unreliable source", "false claim",
+    "bogus report", "made-up story", "fake report", "misinformation campaign",
+    "distorted facts", "conspiracy theory", "falsified news", "untruth", "sensationalized",
+    "fake headline", "misleading article", "deceptive story", "questionable source",
+    "hoax report", "unconfirmed news", "false story", NULL
 };
 
 static const char *EXAGGERATED_WORDS[] = {
@@ -374,6 +297,33 @@ static const char *EXAGGERATED_WORDS[] = {
     "amazing",
     "phenomenal",
     NULL
+};
+
+// Category enum
+typedef enum {
+    SOAP_CAT_RAGEBAIT,
+    SOAP_CAT_CLICKBAIT,
+    SOAP_CAT_SPAM,
+    SOAP_CAT_WOKE,
+    SOAP_CAT_PROPAGANDA,
+    SOAP_CAT_BOT,
+    SOAP_CAT_FAKE_NEWS,
+    SOAP_CAT_SARCASM,      // New category
+    SOAP_CAT_FORMAL,       // New category
+    SOAP_CAT_COUNT          // Sentinel
+} soap_category_t;
+
+// Detector registry
+static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
+    { SOAP_CAT_RAGEBAIT,  "ragebait",  SOAP_RAGEBAIT_PATTERNS,  fossil_io_soap_detect_ragebait },
+    { SOAP_CAT_CLICKBAIT, "clickbait", SOAP_CLICKBAIT_PATTERNS, fossil_io_soap_detect_clickbait },
+    { SOAP_CAT_SPAM,      "spam",      SOAP_SPAM_PATTERNS,      fossil_io_soap_detect_spam },
+    { SOAP_CAT_WOKE,      "woke",      SOAP_WOKE_PATTERNS,      fossil_io_soap_detect_woke },
+    { SOAP_CAT_PROPAGANDA,"propaganda",SOAP_PROPAGANDA_PATTERNS,fossil_io_soap_detect_propaganda },
+    { SOAP_CAT_BOT,       "bot",       SOAP_BOT_PATTERNS,       fossil_io_soap_detect_bot },
+    { SOAP_CAT_FAKE_NEWS, "fake",      SOAP_FAKE_NEWS_PATTERNS, fossil_io_soap_detect_fake_news },
+    { SOAP_CAT_SARCASM,   "sarcasm",   SOAP_SARCASTIC_PATTERNS, fossil_io_soap_detect_sarcasm },
+    { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal }
 };
 
 static char custom_storage[MAX_CUSTOM_FILTERS][64];
@@ -524,6 +474,31 @@ static const char *fossil_io_soap_get_suggestion(const char *word) {
     return NULL;
 }
 
+static int soap_detect_patterns(const char *text, const char **patterns) {
+    if (!text || !patterns) return 0;
+    for (int i = 0; patterns[i]; i++) {
+        if (custom_strcasestr(text, patterns[i])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int fossil_io_soap_detect_category(const char *text, soap_category_t category, soap_ti_reason_t *reason) {
+    if (!text || category >= SOAP_CAT_COUNT) return 0;
+
+    const soap_detector_t *detector = &SOAP_DETECTORS[category];
+    if (detector->detect(text)) {
+        if (reason) {
+            reason->category_name = detector->name;
+            reason->matched_pattern = "Pattern match"; // Could enhance to store exact phrase
+            reason->confidence = 100; // Simple scoring, could be enhanced
+        }
+        return 1;
+    }
+    return 0;
+}
+
 /**
  * @brief Sanitize input text by removing or replacing "rot-brain" and meme-based language.
  * @param censor_char Character to use for censored words (e.g., "*" or "#").
@@ -647,19 +622,17 @@ void fossil_io_soap_clear_custom_filters(void) {
 }
 
 const char *fossil_io_soap_detect_tone(const char *text) {
-    for (size_t i = 0; SARCASTIC_PHRASES[i] != NULL; i++) {
-        if (custom_strcasestr(text, SARCASTIC_PHRASES[i])) {
-            return "sarcastic";
+    if (!text) return "unknown";
+
+    // Iterate over all detectors
+    for (size_t i = 0; i < SOAP_CAT_COUNT; i++) {
+        const soap_detector_t *detector = &SOAP_DETECTORS[i];
+        if (detector->detect_fn && detector->detect_fn(text)) {
+            return detector->name; // Return category name
         }
     }
 
-    for (size_t i = 0; FORMAL_PHRASES[i] != NULL; i++) {
-        if (custom_strcasestr(text, FORMAL_PHRASES[i])) {
-            return "formal";
-        }
-    }
-
-    return "casual";
+    return "casual"; // Default tone
 }
 
 int fossil_io_soap_check_grammar(const char *text) {
@@ -745,27 +718,39 @@ char *fossil_io_soap_normalize_slang(const char *text) {
 }
 
 int fossil_io_soap_detect_ragebait(const char *text) {
-    if (!text) return 0;
-
-    for (int i = 0; RAGEBAIT_PATTERNS[i] != NULL; i++) {
-        if (custom_strcasestr(text, RAGEBAIT_PATTERNS[i])) {
-            return 1;
-        }
-    }
-
-    return 0;
+    return soap_detect_patterns(text, SOAP_RAGEBAIT_PATTERNS);
 }
 
 int fossil_io_soap_detect_clickbait(const char *text) {
-    if (!text) return 0;
+    return soap_detect_patterns(text, SOAP_CLICKBAIT_PATTERNS);
+}
 
-    for (int i = 0; CLICKBAIT_PATTERNS[i] != NULL; i++) {
-        if (custom_strcasestr(text, CLICKBAIT_PATTERNS[i])) {
-            return 1;
-        }
-    }
+int fossil_io_soap_detect_spam(const char *text) {
+    return soap_detect_patterns(text, SOAP_SPAM_PATTERNS);
+}
 
-    return 0;
+int fossil_io_soap_detect_woke(const char *text) {
+    return soap_detect_patterns(text, SOAP_WOKE_PATTERNS);
+}
+
+int fossil_io_soap_detect_propaganda(const char *text) {
+    return soap_detect_patterns(text, SOAP_PROPAGANDA_PATTERNS);
+}
+
+int fossil_io_soap_detect_bot(const char *text) {
+    return soap_detect_patterns(text, SOAP_BOT_PATTERNS);
+}
+
+int fossil_io_soap_detect_fake_news(const char *text) {
+    return soap_detect_patterns(text, SOAP_FAKE_NEWS_PATTERNS);
+}
+
+int fossil_io_soap_detect_sarcasm(const char *text) {
+    return soap_detect_patterns(text, SOAP_SARCASTIC_PATTERNS);
+}
+
+int fossil_io_soap_detect_formal(const char *text) {
+    return soap_detect_patterns(text, SOAP_FORMAL_PATTERNS);
 }
 
 int fossil_io_soap_detect_exaggeration(const char *text) {
@@ -814,16 +799,6 @@ int fossil_io_soap_detect_exaggeration(const char *text) {
     }
     if (caps_word) return 1;
 
-    return 0;
-}
-
-int fossil_io_soap_detect_spam(const char *text) {
-    if (!text) return 0;
-    for (int i = 0; SOAP_SPAM_PATTERNS[i] != NULL; i++) {
-        if (strcasestr(text, SOAP_SPAM_PATTERNS[i])) {
-            return 1;
-        }
-    }
     return 0;
 }
 

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -268,6 +268,80 @@ static const char *RAGEBAIT_PATTERNS[] = {
     NULL // Sentinel
 };
 
+// Expanded spammy phrase patterns
+static const char *SOAP_SPAM_PATTERNS[] = {
+    // Generic spam
+    "free money",
+    "work from home",
+    "earn cash fast",
+    "make money online",
+    "quick cash",
+    "get rich quick",
+    "increase followers",
+    "buy now",
+    "limited time offer",
+    "act now",
+    "click here",
+    "exclusive deal",
+
+    // Health/Scam spam
+    "lose weight fast",
+    "miracle cure",
+    "anti aging",
+    "magic pill",
+    "instant results",
+
+    // Financial spam
+    "guaranteed income",
+    "credit repair",
+    "low interest rate",
+    "investment opportunity",
+    "winner",
+    "lottery",
+    "claim your prize",
+    "100% free",
+    "no risk",
+
+    // Symbols/spam tricks
+    "$$$",
+    "###",
+    "!!!",
+    NULL
+};
+
+// Expanded woke-tone phrase patterns
+static const char *SOAP_WOKE_PATTERNS[] = {
+    // Identity & equity
+    "diversity and inclusion",
+    "equity over equality",
+    "social justice",
+    "systemic oppression",
+    "white privilege",
+    "check your privilege",
+    "lived experience",
+    "cultural appropriation",
+
+    // Gender & sexuality
+    "gender identity",
+    "gender fluid",
+    "non-binary",
+    "pronouns",
+    "misgender",
+    "deadname",
+    "trans rights",
+
+    // Safety & sensitivity
+    "safe space",
+    "trigger warning",
+    "microaggression",
+    "toxic masculinity",
+    "patriarchy",
+    "mansplaining",
+    "intersectionality",
+
+    NULL
+};
+
 static const char *EXAGGERATED_WORDS[] = {
     "literally",
     "always",
@@ -743,33 +817,18 @@ int fossil_io_soap_detect_exaggeration(const char *text) {
     return 0;
 }
 
+int fossil_io_soap_detect_spam(const char *text) {
+    if (!text) return 0;
+    for (int i = 0; SOAP_SPAM_PATTERNS[i] != NULL; i++) {
+        if (strcasestr(text, SOAP_SPAM_PATTERNS[i])) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 char *fossil_io_soap_filter_offensive(const char *text) {
     if (!text) return NULL;
-
-    static const struct {
-        const char *offensive;
-        const char *replacement;
-    } OFFENSIVE_WORDS[] = {
-        {"dumb", "uninformed"},
-        {"stupid", "ill-advised"},
-        {"idiot", "misguided"},
-        {"moron", "uninformed"},
-        {"sucks", "is not ideal"},
-        {"fool", "misguided"},
-        {"jerk", "unpleasant person"},
-        {"loser", "underperformer"},
-        {"dork", "awkward person"},
-        {"lame", "unsatisfactory"},
-        {"crazy", "unreasonable"},
-        {"idiotic", "poorly thought out"},
-        {"dunce", "uninformed individual"},
-        {"nasty", "unpleasant"},
-        {"worthless", "lacking value"},
-        {"pathetic", "disappointing"},
-        {"dimwit", "uninformed"},
-        {"clueless", "uninformed"},
-        {NULL, NULL}
-    };
 
     char *result = fossil_io_cstring_dup(text);
     if (!result) return NULL;

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -265,6 +265,40 @@ static const char *SOAP_FAKE_NEWS_PATTERNS[] = {
     "hoax report", "unconfirmed news", "false story", NULL
 };
 
+static const char *SOAP_SNOWFLAKE_PATTERNS[] = {
+    "snowflake",
+    "triggered",
+    "fragile ego",
+    "offended easily",
+    "sensitive snowflake",
+    "microaggression",
+    "safe space",
+    "special snowflake",
+    "delicate",
+    "thin-skinned",
+    "overly sensitive",
+    "crybaby",
+    "tender feelings",
+    "too sensitive",
+    "emotionally fragile",
+    "overreacting",
+    "touchy",
+    "soft-hearted",
+    "extra sensitive",
+    "hyper-sensitive",
+    "prickly",
+    "easily upset",
+    "nervous nellie",
+    "fragile personality",
+    "highly sensitive",
+    "overly emotional",
+    "whiny",
+    "melodramatic",
+    "delicate flower",
+    "fragile soul",
+    NULL
+};
+
 static const char *EXAGGERATED_WORDS[] = {
     "literally",
     "always",
@@ -323,6 +357,7 @@ static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
     { SOAP_CAT_BOT,       "bot",       SOAP_BOT_PATTERNS,       fossil_io_soap_detect_bot },
     { SOAP_CAT_FAKE_NEWS, "fake",      SOAP_FAKE_NEWS_PATTERNS, fossil_io_soap_detect_fake_news },
     { SOAP_CAT_SARCASM,   "sarcasm",   SOAP_SARCASTIC_PATTERNS, fossil_io_soap_detect_sarcasm },
+    { SOAP_CAT_SNOWFLAKE, "snowflake", SOAP_SNOWFLAKE_PATTERNS, fossil_io_soap_detect_snowflake },
     { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal }
 };
 
@@ -751,6 +786,10 @@ int fossil_io_soap_detect_sarcasm(const char *text) {
 
 int fossil_io_soap_detect_formal(const char *text) {
     return soap_detect_patterns(text, SOAP_FORMAL_PATTERNS);
+}
+
+int fossil_io_soap_detect_snowflake(const char *text) {
+    return soap_detect_patterns(text, SOAP_SNOWFLAKE_PATTERNS);
 }
 
 int fossil_io_soap_detect_exaggeration(const char *text) {

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -299,6 +299,41 @@ static const char *SOAP_SNOWFLAKE_PATTERNS[] = {
     NULL
 };
 
+/** Lookup table for offensive content detection */
+static const char *SOAP_OFFENSIVE_PATTERNS[] = {
+    "idiot",
+    "stupid",
+    "dumb",
+    "moron",
+    "fool",
+    "loser",
+    "jerk",
+    "trash",
+    "garbage",
+    "worthless",
+    "pathetic",
+    "ugly",
+    "disgusting",
+    "nonsense",
+    "ridiculous",
+    "absurd",
+    "hate",
+    "kill",
+    "die",
+    "sucks",
+    "shut up",
+    "loser",
+    "dunce",
+    "ignorant",
+    "nasty",
+    "offensive",
+    "freak",
+    "creep",
+    "weirdo",
+    "worthless",
+    NULL // Sentinel to mark the end
+};
+
 static const char *EXAGGERATED_WORDS[] = {
     "literally",
     "always",
@@ -358,7 +393,8 @@ static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
     { SOAP_CAT_FAKE_NEWS, "fake",      SOAP_FAKE_NEWS_PATTERNS, fossil_io_soap_detect_fake_news },
     { SOAP_CAT_SARCASM,   "sarcasm",   SOAP_SARCASTIC_PATTERNS, fossil_io_soap_detect_sarcasm },
     { SOAP_CAT_SNOWFLAKE, "snowflake", SOAP_SNOWFLAKE_PATTERNS, fossil_io_soap_detect_snowflake },
-    { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal }
+    { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal },
+    { SOAP_CAT_OFFENSIVE, "offensive", SOAP_OFFENSIVE_PATTERNS, fossil_io_soap_detect_offensive }
 };
 
 static char custom_storage[MAX_CUSTOM_FILTERS][64];
@@ -800,6 +836,10 @@ int fossil_io_soap_detect_snowflake(const char *text) {
     return soap_detect_patterns(text, SOAP_SNOWFLAKE_PATTERNS);
 }
 
+int fossil_io_soap_detect_offensive(const char *text) {
+    return soap_detect_patterns(text, SOAP_OFFENSIVE_PATTERNS);
+}
+
 int fossil_io_soap_detect_exaggeration(const char *text) {
     if (!text) return 0;
 
@@ -855,9 +895,9 @@ char *fossil_io_soap_filter_offensive(const char *text) {
     char *result = fossil_io_cstring_dup(text);
     if (!result) return NULL;
 
-    for (size_t i = 0; OFFENSIVE_WORDS[i].offensive != NULL; i++) {
-        const char *bad = OFFENSIVE_WORDS[i].offensive;
-        const char *good = OFFENSIVE_WORDS[i].replacement;
+    for (size_t i = 0; SOAP_OFFENSIVE_PATTERNS[i].offensive != NULL; i++) {
+        const char *bad = SOAP_OFFENSIVE_PATTERNS[i].offensive;
+        const char *good = SOAP_OFFENSIVE_PATTERNS[i].replacement;
 
         const char *found = NULL;
         while ((found = custom_strcasestr(result, bad)) != NULL) {

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -30,8 +30,27 @@ typedef enum {
     SOAP_CAT_PROPAGANDA,
     SOAP_CAT_BOT,
     SOAP_CAT_FAKE_NEWS,
-    SOAP_CAT_COUNT   // Sentinel
+    SOAP_CAT_SARCASM,
+    SOAP_CAT_FORMAL,
+    SOAP_CAT_SNOWFLAKE,   // Added missing
+    SOAP_CAT_OFFENSIVE,    // Added missing
+    SOAP_CAT_COUNT         // Sentinel
 } soap_category_t;
+
+// Detector registry
+static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
+    { SOAP_CAT_RAGEBAIT,  "ragebait",  SOAP_RAGEBAIT_PATTERNS,  fossil_io_soap_detect_ragebait },
+    { SOAP_CAT_CLICKBAIT, "clickbait", SOAP_CLICKBAIT_PATTERNS, fossil_io_soap_detect_clickbait },
+    { SOAP_CAT_SPAM,      "spam",      SOAP_SPAM_PATTERNS,      fossil_io_soap_detect_spam },
+    { SOAP_CAT_WOKE,      "woke",      SOAP_WOKE_PATTERNS,      fossil_io_soap_detect_woke },
+    { SOAP_CAT_PROPAGANDA,"propaganda",SOAP_PROPAGANDA_PATTERNS,fossil_io_soap_detect_propaganda },
+    { SOAP_CAT_BOT,       "bot",       SOAP_BOT_PATTERNS,       fossil_io_soap_detect_bot },
+    { SOAP_CAT_FAKE_NEWS, "fake",      SOAP_FAKE_NEWS_PATTERNS, fossil_io_soap_detect_fake_news },
+    { SOAP_CAT_SARCASM,   "sarcasm",   SOAP_SARCASTIC_PATTERNS, fossil_io_soap_detect_sarcasm },
+    { SOAP_CAT_SNOWFLAKE, "snowflake", SOAP_SNOWFLAKE_PATTERNS, fossil_io_soap_detect_snowflake },
+    { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal },
+    { SOAP_CAT_OFFENSIVE, "offensive", SOAP_OFFENSIVE_PATTERNS, fossil_io_soap_detect_offensive },
+};
 
 // Detector function type
 typedef int (*soap_detector_fn)(const char *text);
@@ -366,35 +385,6 @@ static const char *EXAGGERATED_WORDS[] = {
     "amazing",
     "phenomenal",
     NULL
-};
-
-// Category enum
-typedef enum {
-    SOAP_CAT_RAGEBAIT,
-    SOAP_CAT_CLICKBAIT,
-    SOAP_CAT_SPAM,
-    SOAP_CAT_WOKE,
-    SOAP_CAT_PROPAGANDA,
-    SOAP_CAT_BOT,
-    SOAP_CAT_FAKE_NEWS,
-    SOAP_CAT_SARCASM,      // New category
-    SOAP_CAT_FORMAL,       // New category
-    SOAP_CAT_COUNT          // Sentinel
-} soap_category_t;
-
-// Detector registry
-static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
-    { SOAP_CAT_RAGEBAIT,  "ragebait",  SOAP_RAGEBAIT_PATTERNS,  fossil_io_soap_detect_ragebait },
-    { SOAP_CAT_CLICKBAIT, "clickbait", SOAP_CLICKBAIT_PATTERNS, fossil_io_soap_detect_clickbait },
-    { SOAP_CAT_SPAM,      "spam",      SOAP_SPAM_PATTERNS,      fossil_io_soap_detect_spam },
-    { SOAP_CAT_WOKE,      "woke",      SOAP_WOKE_PATTERNS,      fossil_io_soap_detect_woke },
-    { SOAP_CAT_PROPAGANDA,"propaganda",SOAP_PROPAGANDA_PATTERNS,fossil_io_soap_detect_propaganda },
-    { SOAP_CAT_BOT,       "bot",       SOAP_BOT_PATTERNS,       fossil_io_soap_detect_bot },
-    { SOAP_CAT_FAKE_NEWS, "fake",      SOAP_FAKE_NEWS_PATTERNS, fossil_io_soap_detect_fake_news },
-    { SOAP_CAT_SARCASM,   "sarcasm",   SOAP_SARCASTIC_PATTERNS, fossil_io_soap_detect_sarcasm },
-    { SOAP_CAT_SNOWFLAKE, "snowflake", SOAP_SNOWFLAKE_PATTERNS, fossil_io_soap_detect_snowflake },
-    { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal },
-    { SOAP_CAT_OFFENSIVE, "offensive", SOAP_OFFENSIVE_PATTERNS, fossil_io_soap_detect_offensive },
 };
 
 static char custom_storage[MAX_CUSTOM_FILTERS][64];

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -37,6 +37,17 @@ typedef enum {
     SOAP_CAT_COUNT         // Sentinel
 } soap_category_t;
 
+// Detector function type
+typedef int (*soap_detector_fn)(const char *text);
+
+// Detector registry entry
+typedef struct {
+    soap_category_t category;     // Category
+    const char *name;             // Human-readable name
+    const char **patterns;         // Lookup table of phrases
+    soap_detector_fn detect_fn;     // Optional custom function
+} soap_detector_t;
+
 // Detector registry
 static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
     { SOAP_CAT_RAGEBAIT,  "ragebait",  SOAP_RAGEBAIT_PATTERNS,  fossil_io_soap_detect_ragebait },
@@ -49,19 +60,8 @@ static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
     { SOAP_CAT_SARCASM,   "sarcasm",   SOAP_SARCASTIC_PATTERNS, fossil_io_soap_detect_sarcasm },
     { SOAP_CAT_SNOWFLAKE, "snowflake", SOAP_SNOWFLAKE_PATTERNS, fossil_io_soap_detect_snowflake },
     { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal },
-    { SOAP_CAT_OFFENSIVE, "offensive", SOAP_OFFENSIVE_PATTERNS, fossil_io_soap_detect_offensive },
+    { SOAP_CAT_OFFENSIVE, "offensive", SOAP_OFFENSIVE_PATTERNS, fossil_io_soap_detect_offensive }
 };
-
-// Detector function type
-typedef int (*soap_detector_fn)(const char *text);
-
-// Detector registry entry
-typedef struct {
-    soap_category_t category;     // Category
-    const char *name;             // Human-readable name
-    const char **patterns;         // Lookup table of phrases
-    soap_detector_fn detect_fn;     // Optional custom function
-} soap_detector_t;
 
 // Optional: reasoning / TI metadata
 typedef struct {

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -892,12 +892,37 @@ int fossil_io_soap_detect_exaggeration(const char *text) {
 char *fossil_io_soap_filter_offensive(const char *text) {
     if (!text) return NULL;
 
+    static const struct {
+        const char *offensive;
+        const char *replacement;
+    } OFFENSIVE_WORDS[] = {
+        {"dumb", "uninformed"},
+        {"stupid", "ill-advised"},
+        {"idiot", "misguided"},
+        {"moron", "uninformed"},
+        {"sucks", "is not ideal"},
+        {"fool", "misguided"},
+        {"jerk", "unpleasant person"},
+        {"loser", "underperformer"},
+        {"dork", "awkward person"},
+        {"lame", "unsatisfactory"},
+        {"crazy", "unreasonable"},
+        {"idiotic", "poorly thought out"},
+        {"dunce", "uninformed individual"},
+        {"nasty", "unpleasant"},
+        {"worthless", "lacking value"},
+        {"pathetic", "disappointing"},
+        {"dimwit", "uninformed"},
+        {"clueless", "uninformed"},
+        {NULL, NULL}
+    };
+
     char *result = fossil_io_cstring_dup(text);
     if (!result) return NULL;
 
-    for (size_t i = 0; FOSSIL_SOAP_SUGGESTIONS[i].offensive != NULL; i++) {
-        const char *bad = FOSSIL_SOAP_SUGGESTIONS[i].offensive;
-        const char *good = FOSSIL_SOAP_SUGGESTIONS[i].replacement;
+    for (size_t i = 0; OFFENSIVE_WORDS[i].offensive != NULL; i++) {
+        const char *bad = OFFENSIVE_WORDS[i].offensive;
+        const char *good = OFFENSIVE_WORDS[i].replacement;
 
         const char *found = NULL;
         while ((found = custom_strcasestr(result, bad)) != NULL) {

--- a/code/logic/soap.c
+++ b/code/logic/soap.c
@@ -21,48 +21,6 @@
 
 #define MAX_CUSTOM_FILTERS 64
 
-// Category enum
-typedef enum {
-    SOAP_CAT_RAGEBAIT,
-    SOAP_CAT_CLICKBAIT,
-    SOAP_CAT_SPAM,
-    SOAP_CAT_WOKE,
-    SOAP_CAT_PROPAGANDA,
-    SOAP_CAT_BOT,
-    SOAP_CAT_FAKE_NEWS,
-    SOAP_CAT_SARCASM,
-    SOAP_CAT_FORMAL,
-    SOAP_CAT_SNOWFLAKE,   // Added missing
-    SOAP_CAT_OFFENSIVE,    // Added missing
-    SOAP_CAT_COUNT         // Sentinel
-} soap_category_t;
-
-// Detector function type
-typedef int (*soap_detector_fn)(const char *text);
-
-// Detector registry entry
-typedef struct {
-    soap_category_t category;     // Category
-    const char *name;             // Human-readable name
-    const char **patterns;         // Lookup table of phrases
-    soap_detector_fn detect_fn;     // Optional custom function
-} soap_detector_t;
-
-// Detector registry
-static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
-    { SOAP_CAT_RAGEBAIT,  "ragebait",  SOAP_RAGEBAIT_PATTERNS,  fossil_io_soap_detect_ragebait },
-    { SOAP_CAT_CLICKBAIT, "clickbait", SOAP_CLICKBAIT_PATTERNS, fossil_io_soap_detect_clickbait },
-    { SOAP_CAT_SPAM,      "spam",      SOAP_SPAM_PATTERNS,      fossil_io_soap_detect_spam },
-    { SOAP_CAT_WOKE,      "woke",      SOAP_WOKE_PATTERNS,      fossil_io_soap_detect_woke },
-    { SOAP_CAT_PROPAGANDA,"propaganda",SOAP_PROPAGANDA_PATTERNS,fossil_io_soap_detect_propaganda },
-    { SOAP_CAT_BOT,       "bot",       SOAP_BOT_PATTERNS,       fossil_io_soap_detect_bot },
-    { SOAP_CAT_FAKE_NEWS, "fake",      SOAP_FAKE_NEWS_PATTERNS, fossil_io_soap_detect_fake_news },
-    { SOAP_CAT_SARCASM,   "sarcasm",   SOAP_SARCASTIC_PATTERNS, fossil_io_soap_detect_sarcasm },
-    { SOAP_CAT_SNOWFLAKE, "snowflake", SOAP_SNOWFLAKE_PATTERNS, fossil_io_soap_detect_snowflake },
-    { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal },
-    { SOAP_CAT_OFFENSIVE, "offensive", SOAP_OFFENSIVE_PATTERNS, fossil_io_soap_detect_offensive }
-};
-
 // Optional: reasoning / TI metadata
 typedef struct {
     const char *category_name;
@@ -385,6 +343,48 @@ static const char *EXAGGERATED_WORDS[] = {
     "amazing",
     "phenomenal",
     NULL
+};
+
+// Category enum
+typedef enum {
+    SOAP_CAT_RAGEBAIT,
+    SOAP_CAT_CLICKBAIT,
+    SOAP_CAT_SPAM,
+    SOAP_CAT_WOKE,
+    SOAP_CAT_PROPAGANDA,
+    SOAP_CAT_BOT,
+    SOAP_CAT_FAKE_NEWS,
+    SOAP_CAT_SARCASM,
+    SOAP_CAT_FORMAL,
+    SOAP_CAT_SNOWFLAKE,   // Added missing
+    SOAP_CAT_OFFENSIVE,    // Added missing
+    SOAP_CAT_COUNT         // Sentinel
+} soap_category_t;
+
+// Detector function type
+typedef int (*soap_detector_fn)(const char *text);
+
+// Detector registry entry
+typedef struct {
+    soap_category_t category;     // Category
+    const char *name;             // Human-readable name
+    const char **patterns;         // Lookup table of phrases
+    soap_detector_fn detect_fn;     // Optional custom function
+} soap_detector_t;
+
+// Detector registry
+static const soap_detector_t SOAP_DETECTORS[SOAP_CAT_COUNT] = {
+    { SOAP_CAT_RAGEBAIT,  "ragebait",  SOAP_RAGEBAIT_PATTERNS,  fossil_io_soap_detect_ragebait },
+    { SOAP_CAT_CLICKBAIT, "clickbait", SOAP_CLICKBAIT_PATTERNS, fossil_io_soap_detect_clickbait },
+    { SOAP_CAT_SPAM,      "spam",      SOAP_SPAM_PATTERNS,      fossil_io_soap_detect_spam },
+    { SOAP_CAT_WOKE,      "woke",      SOAP_WOKE_PATTERNS,      fossil_io_soap_detect_woke },
+    { SOAP_CAT_PROPAGANDA,"propaganda",SOAP_PROPAGANDA_PATTERNS,fossil_io_soap_detect_propaganda },
+    { SOAP_CAT_BOT,       "bot",       SOAP_BOT_PATTERNS,       fossil_io_soap_detect_bot },
+    { SOAP_CAT_FAKE_NEWS, "fake",      SOAP_FAKE_NEWS_PATTERNS, fossil_io_soap_detect_fake_news },
+    { SOAP_CAT_SARCASM,   "sarcasm",   SOAP_SARCASTIC_PATTERNS, fossil_io_soap_detect_sarcasm },
+    { SOAP_CAT_SNOWFLAKE, "snowflake", SOAP_SNOWFLAKE_PATTERNS, fossil_io_soap_detect_snowflake },
+    { SOAP_CAT_FORMAL,    "formal",    SOAP_FORMAL_PATTERNS,    fossil_io_soap_detect_formal },
+    { SOAP_CAT_OFFENSIVE, "offensive", SOAP_OFFENSIVE_PATTERNS, fossil_io_soap_detect_offensive }
 };
 
 static char custom_storage[MAX_CUSTOM_FILTERS][64];


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description
This soap extension patch adds detection for spam phrases and woke phrases to better protect against these two types of annoying spam.

## Testing
<!-- Describe the testing process or steps taken to ensure the changes work as expected. -->

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
