### PR TITLE
Add color builtin toggle 

### DIFF
--- a/code/logic/parser.c
+++ b/code/logic/parser.c
@@ -423,6 +423,37 @@ void fossil_io_parser_parse(fossil_io_parser_palette_t *palette, int argc, char 
             break;
         }
 
+        if (strcmp(arg, "--color") == 0) {
+            FOSSIL_IO_COLOR_ENABLE = 1;
+            global_flags_processed = 1;
+            break;
+        }
+        else if (strcmp(arg, "--no-color") == 0) {
+            FOSSIL_IO_COLOR_ENABLE = 0;
+            global_flags_processed = 1;
+            break;
+        }
+        else if (strcmp(arg, "--color=auto") == 0) {
+            FOSSIL_IO_COLOR_ENABLE = -1; // let runtime decide
+            global_flags_processed = 1;
+            break;
+        }
+        else if (strncmp(arg, "--color=", 8) == 0) {
+            const char *mode = arg + 8;
+            if (strcmp(mode, "enable") == 0) {
+                FOSSIL_IO_COLOR_ENABLE = 1;
+            } else if (strcmp(mode, "disable") == 0) {
+                FOSSIL_IO_COLOR_ENABLE = 0;
+            } else if (strcmp(mode, "auto") == 0) {
+                FOSSIL_IO_COLOR_ENABLE = -1;
+            } else {
+                fprintf(stderr, "Unknown --color option: %s\n", mode);
+                exit(EXIT_FAILURE);
+            }
+            global_flags_processed = 1;
+            break;
+        }
+
         if (strcmp(arg, "--version") == 0) {
             show_version();
             global_flags_processed = 1;


### PR DESCRIPTION
# Fossil XSDK Pull Request

## Description
This adds a builtin toggle for the color flag, this color flag is tied with the output functions which output colored text based on the fstring tags and the flag that is exposed for command line purposes.

## Testing
<!-- Describe the testing process or steps taken to ensure the changes work as expected. -->

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
